### PR TITLE
Upgrade Go to 1.24.4 to address security vulnerabilities

### DIFF
--- a/functions/itsmhelper/go.mod
+++ b/functions/itsmhelper/go.mod
@@ -1,6 +1,6 @@
 module itsmhelper
 
-go 1.24.0
+go 1.24.4
 
 require (
 	github.com/CrowdStrike/foundry-fn-go v0.24.1


### PR DESCRIPTION
Fixes 3 security vulnerabilities in Go standard library by upgrading from Go 1.24.0 to 1.24.4.

## Security Vulnerabilities Fixed

1. **[GO-2025-3751](https://pkg.go.dev/vuln/GO-2025-3751)** - Sensitive headers not cleared on cross-origin redirect in net/http
2. **[GO-2025-3750](https://pkg.go.dev/vuln/GO-2025-3750)** - Inconsistent handling of O_CREATE|O_EXCL on Unix and Windows in os/syscall
3. **[GO-2025-3749](https://pkg.go.dev/vuln/GO-2025-3749)** - ExtKeyUsageAny disables policy validation in crypto/x509

## Changes
- Updated `go.mod`: `go 1.24.0` → `go 1.24.4`

All vulnerabilities are resolved in Go 1.24.4.