### PR TITLE
Set Go version to 1.24

### DIFF
--- a/functions/itsmhelper/go.mod
+++ b/functions/itsmhelper/go.mod
@@ -1,6 +1,6 @@
 module itsmhelper
 
-go 1.24.4
+go 1.24
 
 require (
 	github.com/CrowdStrike/foundry-fn-go v0.24.1


### PR DESCRIPTION
Updates Go version from 1.24.4 to 1.24 to use the minor version constraint instead of a patch version.

This allows the build to automatically pick up patch releases while maintaining compatibility with Go 1.24.