### PR TITLE
Update gofalcon to v0.17.0 to fix compilation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The ServiceNow ITSM and SIR is a Foundry application that enables seamless integ
 ## Prerequisites
 
 * The Foundry CLI (instructions below).
-* Golang (needed if modifying the app's functions).
+* Go v1.24+ (needed if modifying the app's functions). See https://go.dev/learn for installation instructions.
 * A ServiceNow instance with ITSM and/or SIR module installed.
 
 ### Install the Foundry CLI

--- a/functions/itsmhelper/go.mod
+++ b/functions/itsmhelper/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 require (
 	github.com/CrowdStrike/foundry-fn-go v0.24.1
-	github.com/crowdstrike/gofalcon v0.16.0
+	github.com/crowdstrike/gofalcon v0.17.0
 	github.com/go-openapi/runtime v0.29.0
 	github.com/stretchr/testify v1.11.1
 )


### PR DESCRIPTION
Updated dependencies to address compilation errors.

## Changes
- github.com/crowdstrike/gofalcon: 0.16.0 → 0.17.0
- README.md: Updated Go prerequisite to v1.24+ with installation link

## Issue
gofalcon v0.16.0 had compilation errors related to undefined container image and package models.

## Testing
- ✅ No vulnerabilities found (govulncheck)
- ✅ Project builds successfully