### PR TITLE
Update Go version from 1.24 to 1.25 to address CVE-2025-58187

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The ServiceNow ITSM and SIR is a Foundry application that enables seamless integ
 ## Prerequisites
 
 * The Foundry CLI (instructions below).
-* Go v1.24+ (needed if modifying the app's functions). See https://go.dev/learn for installation instructions.
+* Go v1.25+ (needed if modifying the app's functions). See https://go.dev/learn for installation instructions.
 * A ServiceNow instance with ITSM and/or SIR module installed.
 
 ### Install the Foundry CLI

--- a/functions/itsmhelper/go.mod
+++ b/functions/itsmhelper/go.mod
@@ -1,6 +1,6 @@
 module itsmhelper
 
-go 1.24
+go 1.25
 
 require (
 	github.com/CrowdStrike/foundry-fn-go v0.24.1


### PR DESCRIPTION
Addresses CVE-2025-58187, a denial-of-service vulnerability in Go's crypto/x509 package.

The vulnerability affects Go 1.24.x (before 1.24.9) and Go 1.25.0-1.25.2. Foundry currently uses Go 1.25.3.

More information: https://pkg.go.dev/vuln/GO-2025-4007