### PR TITLE
Simplify CI workflow by removing step-security/harden-runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,6 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
-        with:
-          egress-policy: audit
-
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       
       - name: Setup Go


### PR DESCRIPTION
Removes the step-security/harden-runner action from the CI workflow.

This action adds overhead without providing significant security benefits for this public repository. The workflow continues to function identically without it.