### PR TITLE
Remove step-security/harden-runner from workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,11 +26,6 @@ jobs:
       FOUNDRY_CID: ${{ secrets.FOUNDRY_CID }}
       FOUNDRY_CLOUD_REGION: ${{ secrets.FOUNDRY_CLOUD_REGION }}
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
-        with:
-          egress-policy: audit
-
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - name: Set up Homebrew


### PR DESCRIPTION
Removes the `step-security/harden-runner` action which is not approved at the org level.