### PR TITLE
Ignore unapproved GitHub Actions versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,8 @@ updates:
       day: "monday"
       time: "14:00"
       timezone: "UTC"
+    ignore:
+      - dependency-name: "actions/setup-node"
+        versions: [">=6.2.0"]
+      - dependency-name: "actions/setup-go"
+        versions: [">=6.2.0"]


### PR DESCRIPTION
Ignores versions not yet on the enterprise approved actions allowlist:
- actions/setup-node >= 6.2.0
- actions/setup-go >= 6.2.0

Closes #46
Closes #47