### PR TITLE
Ignore unapproved GitHub Actions versions in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,8 @@ updates:
       time: "14:00"
       timezone: "UTC"
     ignore:
+      - dependency-name: "actions/checkout"
+        versions: [">=6.0.2"]
       - dependency-name: "actions/setup-node"
         versions: [">=6.2.0"]
       - dependency-name: "actions/setup-go"


### PR DESCRIPTION
Prevents dependabot from creating PRs for GitHub Actions versions that aren't yet on the approved list.