### PR TITLE
Add Python implementation of ITSM helper using falconpy SDK

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,9 +17,9 @@ jobs:
     env:
       PYTHON_VERSION: '3.13'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install global dependencies

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,0 +1,54 @@
+name: Pylint
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '**.py'
+  pull_request:
+    paths:
+      - '**.py'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    env:
+      PYTHON_VERSION: '3.13'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install global dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade pylint
+      - name: Lint all functions
+        run: |
+          # Find all subdirectories in functions/ that contain Python files
+          for func_dir in functions/*/; do
+            if [ -d "$func_dir" ] && find "$func_dir" -name "*.py" -type f | grep -q .; then
+              func_name=$(basename "$func_dir")
+              echo "::group::Processing $func_name"
+
+              # Install function-specific dependencies if requirements.txt exists
+              if [ -f "$func_dir/requirements.txt" ]; then
+                echo "Installing dependencies for $func_name..."
+                pip install -r "$func_dir/requirements.txt"
+              else
+                echo "No requirements.txt found for $func_name, skipping dependency installation"
+              fi
+
+              # Run pylint on the function directory
+              echo "Running pylint on $func_name..."
+              pylint "$func_dir" --max-line-length=127 --disable=R0801 --py-version=${{ env.PYTHON_VERSION }} || {
+                echo "::error::Pylint failed for $func_name"
+                exit 1
+              }
+
+              echo "::endgroup::"
+            fi
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,15 @@
 go.sum
 .DS_Store
 functions/itsmhelper/itsmhelper
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+venv/
+env/
+*.egg-info/
+dist/
+build/

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The ServiceNow ITSM and SIR is a Foundry application that enables seamless integ
 
 * The Foundry CLI (instructions below).
 * **For Go implementation**: Go v1.25+ (needed if modifying the app's Go functions). See https://go.dev/learn for installation instructions.
-* **For Python implementation**: Python 3.8+ (needed if modifying the app's Python functions). See https://www.python.org/downloads/ for installation instructions.
+* **For Python implementation**: Python 3.13+ (needed if modifying the app's Python functions). See https://www.python.org/downloads/ for installation instructions.
 * A ServiceNow instance with ITSM and/or SIR module installed.
 
 ### Implementation Options

--- a/README.md
+++ b/README.md
@@ -31,8 +31,33 @@ The ServiceNow ITSM and SIR is a Foundry application that enables seamless integ
 ## Prerequisites
 
 * The Foundry CLI (instructions below).
-* Go v1.25+ (needed if modifying the app's functions). See https://go.dev/learn for installation instructions.
+* **For Go implementation**: Go v1.25+ (needed if modifying the app's Go functions). See https://go.dev/learn for installation instructions.
+* **For Python implementation**: Python 3.8+ (needed if modifying the app's Python functions). See https://www.python.org/downloads/ for installation instructions.
 * A ServiceNow instance with ITSM and/or SIR module installed.
+
+### Implementation Options
+
+This app is available in two implementations:
+
+- **Go (default)**: High-performance implementation using the gofalcon SDK
+- **Python**: Alternative implementation using the falconpy SDK
+
+Both implementations provide identical functionality. To switch between implementations, modify the `language` field in the `manifest.yml` file:
+
+```yaml
+# For Go implementation (default)
+language: go
+
+# For Python implementation
+language: python
+```
+
+**Python-specific setup**: If you're developing with the Python implementation, install the dependencies:
+
+```shell
+cd functions/itsmhelper
+pip install -r requirements.txt
+```
 
 ### Install the Foundry CLI
 
@@ -98,6 +123,42 @@ foundry apps release
 ```
 
 Next, go to **Foundry** > **App catalog**, find your app, and install it.
+
+## Testing
+
+### Python Unit Tests
+
+If you're working with the Python implementation, you can run the unit tests:
+
+```shell
+cd functions/itsmhelper
+python -m pytest test_main.py -v
+```
+
+To run with coverage:
+
+```shell
+python -m pytest test_main.py --cov=main --cov-report=html
+```
+
+### Go Unit Tests
+
+For the Go implementation:
+
+```shell
+cd functions/itsmhelper
+go test ./... -v
+```
+
+### End-to-End Tests
+
+The e2e tests work with both implementations:
+
+```shell
+cd e2e
+npm install
+npm test
+```
 
 ## About this sample app
 

--- a/functions/itsmhelper/main.py
+++ b/functions/itsmhelper/main.py
@@ -1,0 +1,713 @@
+"""
+ServiceNow ITSM Integration Function - Python Implementation
+
+This function integrates ServiceNow ITSM/SIR with Falcon security alerts.
+It provides endpoints for creating incidents and tracking entity mappings.
+
+Key Features:
+- Check if external entity mappings exist
+- Create entity mappings between internal and external systems
+- Create ServiceNow incidents and SIR incidents
+- Throttling/deduplication for preventing duplicate actions
+- Support for custom fields and flexible configuration
+
+Architecture:
+- Uses falconpy SDK for Falcon API interactions
+- Stores entity mappings in Falcon Custom Storage collections
+- Executes ServiceNow API calls via Falcon API Integrations
+"""
+# pylint: disable=broad-exception-caught
+
+import json
+import hashlib
+import re
+from datetime import datetime, timezone
+from logging import Logger
+from typing import Dict, Any, Optional, Tuple
+from http import HTTPStatus
+
+from crowdstrike.foundry.function import Function, Request, Response, APIError
+from falconpy import APIIntegrations, APIHarnessV2
+
+# Initialize the function instance
+FUNC = Function.instance()
+
+# Constants
+EXTERNAL_SYSTEM_ID_SERVICENOW_INCIDENT = "servicenow_incident"
+EXTERNAL_SYSTEM_ID_SERVICENOW_SIR_INCIDENT = "servicenow_sir_incident"
+
+# Defined in 'api-integrations/servicenow.json'
+PLUGIN_DEF_ID_SERVICENOW = "servicenow-foundry"
+PLUGIN_OP_ID_SERVICENOW_CREATE_INCIDENT = "create_incident"
+PLUGIN_OP_ID_SERVICENOW_CREATE_SIR_INCIDENT = "create_sn_si_incident"
+
+# Collection names
+COLLECTION_NAME_TRACKED_ENTITIES = "tracked_entities"
+COLLECTION_NAME_DEDUP_STORE = "dedup_store"
+
+# Time bucket constants
+TIME_BUCKET_FOREVER = "forever"
+TIME_BUCKET_FIVE_MIN = "5 minutes"
+TIME_BUCKET_THIRTY_MIN = "30 minutes"
+
+
+class ITSMError(Exception):
+    """Base exception for ITSM helper errors."""
+
+
+class StorageError(ITSMError):
+    """Exception for storage-related errors."""
+
+
+class FalconClientError(ITSMError):
+    """Exception for Falcon client errors."""
+
+
+def create_falcon_clients(logger: Logger) -> Tuple[APIIntegrations, APIHarnessV2]:
+    """
+    Create Falcon API clients.
+
+    In the Foundry runtime, authentication is handled automatically
+    via environment variables (FALCON_CLIENT_ID, FALCON_CLIENT_SECRET).
+
+    Args:
+        logger: Logger instance for logging
+
+    Returns:
+        Tuple of (APIIntegrations client, APIHarnessV2 client)
+
+    Raises:
+        FalconClientError: If client creation fails
+    """
+    try:
+        api_integrations = APIIntegrations()
+        api_client = APIHarnessV2()
+
+        return api_integrations, api_client
+
+    except Exception as e:
+        logger.error(f"Error creating Falcon clients: {str(e)}", exc_info=True)
+        raise FalconClientError(f"Failed to create Falcon clients: {str(e)}") from e
+
+
+def sanitize_object_key(input_str: str) -> str:
+    """
+    Sanitize object key to meet custom storage requirements.
+
+    Args:
+        input_str: Input string to sanitize
+
+    Returns:
+        Sanitized object key
+
+    Raises:
+        ValueError: If sanitized key exceeds maximum length
+    """
+    # Replace disallowed characters with underscore
+    sanitized = re.sub(r'[^a-zA-Z0-9._-]', '_', input_str)
+
+    # Check length constraints
+    if len(sanitized) > 1000:
+        raise ValueError(f"Object key exceeds maximum length of 1000 characters: {len(sanitized)}")
+
+    return sanitized
+
+
+def create_tracked_entity_key(external_system_id: str, internal_entity_id: str) -> str:
+    """
+    Generate a unique key for tracked entities.
+
+    Args:
+        external_system_id: External system identifier
+        internal_entity_id: Internal entity identifier
+
+    Returns:
+        Sanitized unique key
+    """
+    combined = f"{external_system_id}.{internal_entity_id}"
+    return sanitize_object_key(combined)
+
+
+def calculate_time_bucket(time_bucket: str) -> str:
+    """
+    Calculate the current time bucket based on the time bucket type.
+
+    Args:
+        time_bucket: Time bucket type (forever, 5 minutes, 30 minutes)
+
+    Returns:
+        Time bucket string
+    """
+    if time_bucket == TIME_BUCKET_FOREVER:
+        return "forever_bucket"
+
+    now = datetime.now(timezone.utc)
+
+    if time_bucket == TIME_BUCKET_FIVE_MIN:
+        # Round down to the nearest 5-minute interval
+        minutes = (now.minute // 5) * 5
+        # Format as "YYYY-MM-DD_HH:MM"
+        date_part = now.strftime("%Y-%m-%d")
+        minute_part = f"{now.hour:02d}:{minutes:02d}"
+        return f"{date_part}_{minute_part}"
+    if time_bucket == TIME_BUCKET_THIRTY_MIN:
+        # Round down to the nearest 30-minute interval
+        minutes = (now.minute // 30) * 30
+        # Format as "YYYY-MM-DD_HH:MM"
+        date_part = now.strftime("%Y-%m-%d")
+        minute_part = f"{now.hour:02d}:{minutes:02d}"
+        return f"{date_part}_{minute_part}"
+
+    raise ValueError(f"Unsupported time bucket: {time_bucket}")
+
+
+def check_external_entity_exists(
+    api_client: APIHarnessV2,
+    _logger: Logger,
+    internal_entity_id: str,
+    external_system_id: str
+) -> Tuple[bool, Optional[Dict[str, str]]]:
+    """
+    Check if an external entity mapping exists.
+
+    Args:
+        api_client: APIHarnessV2 client
+        logger: Logger instance
+        internal_entity_id: Internal entity ID
+        external_system_id: External system ID
+
+    Returns:
+        Tuple of (exists, external_entity_record)
+    """
+    key = create_tracked_entity_key(external_system_id, internal_entity_id)
+
+    response = api_client.command(
+        "GetObject",
+        collection_name=COLLECTION_NAME_TRACKED_ENTITIES,
+        object_key=key
+    )
+
+    # GetObject returns bytes on success, dict on error.
+    # Decode attempt distinguishes success from any error.
+    try:
+        ext_record = json.loads(response.decode('utf-8'))
+    except (AttributeError, UnicodeDecodeError, json.JSONDecodeError):
+        return False, None
+
+    # Verify external_system_id matches if provided
+    if external_system_id and ext_record.get("external_system_id") != external_system_id:
+        return False, None
+
+    return True, ext_record
+
+
+def create_or_update_external_entity_mapping(
+    api_client: APIHarnessV2,
+    logger: Logger,
+    internal_entity_id: str,
+    external_entity_id: str,
+    external_system_id: str
+) -> None:
+    """
+    Create or update an external entity mapping.
+
+    Args:
+        api_client: APIHarnessV2 client
+        logger: Logger instance
+        internal_entity_id: Internal entity ID
+        external_entity_id: External entity ID
+        external_system_id: External system ID
+    """
+    try:
+        key = create_tracked_entity_key(external_system_id, internal_entity_id)
+
+        record = {
+            "internal_entity_id": internal_entity_id,
+            "external_entity_id": external_entity_id,
+            "external_system_id": external_system_id
+        }
+
+        response = api_client.command(
+            "PutObject",
+            collection_name=COLLECTION_NAME_TRACKED_ENTITIES,
+            object_key=key,
+            body=record
+        )
+
+        if response["status_code"] not in [200, 201]:
+            logger.error(f"Failed to store entity mapping: {response}")
+            raise StorageError(f"Failed to store entity mapping: {response}")
+
+        logger.info(
+            f"Successfully stored entity mapping - "
+            f"internal_id: {internal_entity_id}, "
+            f"external_id: {external_entity_id}, "
+            f"system_id: {external_system_id}"
+        )
+
+    except StorageError:
+        raise
+    except Exception as e:
+        logger.error(f"Error storing entity mapping: {str(e)}", exc_info=True)
+        raise StorageError(f"Failed to store entity mapping: {str(e)}") from e
+
+
+def check_throttling_store(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    api_client: APIHarnessV2,
+    logger: Logger,
+    internal_entity_id: str,
+    dedup_obj_type: str,
+    dedup_obj_id: str,
+    time_bucket: str
+) -> bool:
+    """
+    Check if a combination of IDs already exists in throttling store.
+
+    Args:
+        api_client: APIHarnessV2 client
+        logger: Logger instance
+        internal_entity_id: Internal entity ID
+        dedup_obj_type: Deduplication object type
+        dedup_obj_id: Deduplication object ID
+        time_bucket: Time bucket (forever, 5m, 30m)
+
+    Returns:
+        True if duplicate (exists), False if new
+    """
+    # Validate time bucket
+    if time_bucket not in [TIME_BUCKET_FOREVER, TIME_BUCKET_FIVE_MIN, TIME_BUCKET_THIRTY_MIN]:
+        raise ValueError(
+            f"Unsupported time bucket value: {time_bucket} "
+            f"(must be one of: {TIME_BUCKET_FOREVER}, {TIME_BUCKET_FIVE_MIN}, {TIME_BUCKET_THIRTY_MIN})"
+        )
+
+    # Calculate current bucket
+    current_bucket = calculate_time_bucket(time_bucket)
+
+    # Create dedup key
+    combined = f"{internal_entity_id}:{dedup_obj_type}:{dedup_obj_id}:{current_bucket}"
+    dedup_key = hashlib.md5(combined.encode()).hexdigest()
+
+    # Try to get the object — success means duplicate exists
+    response = api_client.command(
+        "GetObject",
+        collection_name=COLLECTION_NAME_DEDUP_STORE,
+        object_key=dedup_key
+    )
+
+    # GetObject returns bytes on success, dict on error.
+    # Decode attempt distinguishes success from any error.
+    try:
+        json.loads(response.decode('utf-8'))
+        return True  # Record exists, it's a duplicate
+    except (AttributeError, UnicodeDecodeError, json.JSONDecodeError):
+        pass
+
+    # Object doesn't exist, create it.
+    logger.info(f"No dedup record found for key: {dedup_key}, creating new entry")
+
+    # Store new dedup record
+    new_record = {"time_bucket": time_bucket}
+    response = api_client.command(
+        "PutObject",
+        collection_name=COLLECTION_NAME_DEDUP_STORE,
+        object_key=dedup_key,
+        body=new_record
+    )
+
+    if response["status_code"] not in [200, 201]:
+        logger.error(f"Failed to store dedup record: {response}")
+        raise StorageError(f"Failed to store dedup record: {response}")
+
+    return False  # New entry, not a duplicate
+
+
+def build_request_payload(body: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Build ServiceNow API request payload from incident request.
+
+    Args:
+        body: Request body
+
+    Returns:
+        Request payload dictionary
+    """
+    request_payload = {
+        "short_description": body.get("short_description", "")
+    }
+
+    # Add optional fields if provided
+    optional_fields = [
+        "assignment_group", "category", "description", "impact",
+        "severity", "state", "urgency", "work_notes"
+    ]
+
+    for field in optional_fields:
+        if body.get(field):
+            request_payload[field] = body[field]
+
+    # Handle custom fields
+    custom_fields_str = body.get("custom_fields")
+    if custom_fields_str:
+        try:
+            custom_fields = json.loads(custom_fields_str) if isinstance(custom_fields_str, str) else custom_fields_str
+            request_payload.update(custom_fields)
+        except json.JSONDecodeError:
+            # Log but don't fail - custom fields are optional
+            pass
+
+    return request_payload
+
+
+@FUNC.handler(path="/check_if_ext_entity_exists", method="POST")
+def check_if_ext_entity_exists_handler(req: Request, _config: Optional[Dict[str, object]], logger: Logger) -> Response:
+    """
+    Check if an external entity mapping exists.
+
+    Request body:
+        - internal_entity_id: Internal entity ID
+        - external_system_id: External system ID
+    """
+    try:
+        logger.info(f"check_if_ext_entity_exists called - trace_id: {req.trace_id}")
+
+        body = req.body
+        internal_entity_id = body.get("internal_entity_id")
+        external_system_id = body.get("external_system_id")
+
+        if not internal_entity_id or not external_system_id:
+            return Response(
+                code=HTTPStatus.BAD_REQUEST,
+                errors=[APIError(
+                    code=HTTPStatus.BAD_REQUEST,
+                    message="Missing required fields: internal_entity_id, external_system_id"
+                )]
+            )
+
+        _, api_client = create_falcon_clients(logger)
+
+        exists, ext_record = check_external_entity_exists(
+            api_client, logger, internal_entity_id, external_system_id
+        )
+
+        if not exists:
+            return Response(
+                code=HTTPStatus.OK,
+                body={"exists": False}
+            )
+
+        return Response(
+            code=HTTPStatus.OK,
+            body={
+                "exists": True,
+                "ext_id": ext_record.get("external_entity_id"),
+                "ext_system_id": ext_record.get("external_system_id")
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"Error in check_if_ext_entity_exists: {str(e)}", exc_info=True)
+        return Response(
+            code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            errors=[APIError(
+                code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                message=f"Internal error: {str(e)}"
+            )]
+        )
+
+
+@FUNC.handler(path="/create_entity_mapping", method="POST")
+def create_entity_mapping_handler(req: Request, _config: Optional[Dict[str, object]], logger: Logger) -> Response:
+    """
+    Create an entity mapping between internal and external systems.
+
+    Request body:
+        - internal_entity_id: Internal entity ID
+        - external_entity_id: External entity ID
+        - external_system_id: External system ID
+    """
+    try:
+        logger.info(f"create_entity_mapping called - trace_id: {req.trace_id}")
+
+        body = req.body
+        internal_entity_id = body.get("internal_entity_id")
+        external_entity_id = body.get("external_entity_id")
+        external_system_id = body.get("external_system_id")
+
+        if not all([internal_entity_id, external_entity_id, external_system_id]):
+            return Response(
+                code=HTTPStatus.BAD_REQUEST,
+                errors=[APIError(
+                    code=HTTPStatus.BAD_REQUEST,
+                    message="Missing required fields: internal_entity_id, external_entity_id, external_system_id"
+                )]
+            )
+
+        _, api_client = create_falcon_clients(logger)
+
+        create_or_update_external_entity_mapping(
+            api_client, logger,
+            internal_entity_id, external_entity_id, external_system_id
+        )
+
+        return Response(
+            code=HTTPStatus.CREATED,
+            body={
+                "internal_entity_id": internal_entity_id,
+                "external_entity_id": external_entity_id,
+                "external_system_id": external_system_id
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"Error in create_entity_mapping: {str(e)}", exc_info=True)
+        return Response(
+            code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            errors=[APIError(
+                code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                message=f"Internal error: {str(e)}"
+            )]
+        )
+
+
+def create_incident_impl(  # pylint: disable=too-many-locals,too-many-return-statements
+    req: Request,
+    logger: Logger,
+    operation_id: str,
+    ticket_type: str,
+    external_system_id: str
+) -> Response:
+    """
+    Common implementation for creating incidents.
+
+    Args:
+        req: Request object
+        logger: Logger instance
+        operation_id: ServiceNow operation ID
+        ticket_type: Ticket type name
+        external_system_id: External system identifier
+
+    Returns:
+        Response object
+    """
+    try:
+        # Log workflow context if present
+        logger.info(
+            f"Creating {ticket_type} - trace_id: {req.trace_id}, workflow_ctx: {req.context}"
+        )
+
+        body = req.body
+        config_id = body.get("config_id")
+        entity_id = body.get("entity_id")
+
+        if not config_id or not entity_id:
+            return Response(
+                code=HTTPStatus.BAD_REQUEST,
+                errors=[APIError(
+                    code=HTTPStatus.BAD_REQUEST,
+                    message="Missing required fields: config_id, entity_id"
+                )]
+            )
+
+        api_integrations, api_client = create_falcon_clients(logger)
+
+        # Check if ticket already exists
+        exists, ext_record = check_external_entity_exists(
+            api_client, logger, entity_id, external_system_id
+        )
+
+        if exists:
+            logger.info(f"Ticket already exists for entity {entity_id}: {ext_record.get('external_entity_id')}")
+            return Response(
+                code=HTTPStatus.OK,
+                body={
+                    "exists": True,
+                    "ticket_id": ext_record.get("external_entity_id"),
+                    "ticket_type": ticket_type
+                }
+            )
+
+        # Build request payload
+        request_payload = build_request_payload(body)
+
+        # Execute API integration command
+        command_body = {
+            "resources": [{
+                "definition_id": PLUGIN_DEF_ID_SERVICENOW,
+                "operation_id": operation_id,
+                "config_id": config_id,
+                "request": {
+                    "json": request_payload
+                }
+            }]
+        }
+
+        exec_response = api_integrations.execute_command(body=command_body)
+
+        status_code = exec_response.get("status_code")
+        logger.info(f"Plugin execution completed - status: {status_code}")
+
+        if status_code not in [200, 201]:
+            errors = exec_response.get("body", {}).get("errors", [])
+            error_msg = errors[0].get("message", "Unknown error") if errors else f"Status {status_code}"
+            logger.error(f"Failed to execute command: {error_msg}")
+            return Response(
+                code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                errors=[APIError(
+                    code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                    message=f"Failed to execute command: {error_msg}"
+                )]
+            )
+
+        # Parse response
+        resources = exec_response.get("body", {}).get("resources", [])
+        if not resources:
+            return Response(
+                code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                errors=[APIError(
+                    code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                    message="Empty response from ServiceNow"
+                )]
+            )
+
+        resource = resources[0]
+        response_body = resource.get("response_body", {})
+
+        # Check for errors
+        if "error" in response_body:
+            error_text = response_body["error"]
+            if isinstance(error_text, dict):
+                error_text = json.dumps(error_text)
+            logger.error(f"ServiceNow error: {error_text}")
+            return Response(
+                code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                errors=[APIError(
+                    code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                    message=f"ServiceNow Error: {error_text}"
+                )]
+            )
+
+        # Extract ticket information
+        result = response_body.get("result", {})
+        snow_sys_class_name = result.get("sys_class_name", "")
+        snow_sys_id = result.get("sys_id", "")
+
+        logger.info(f"Received response from ITSM - ticket_id: {snow_sys_id}, ticket_type: {snow_sys_class_name}")
+
+        # Store entity mapping
+        if snow_sys_id:
+            create_or_update_external_entity_mapping(
+                api_client, logger,
+                entity_id, snow_sys_id, external_system_id
+            )
+
+        return Response(
+            code=HTTPStatus.CREATED,
+            body={
+                "exists": False,
+                "ticket_id": snow_sys_id,
+                "ticket_type": snow_sys_class_name
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"Error creating {ticket_type}: {str(e)}", exc_info=True)
+        return Response(
+            code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            errors=[APIError(
+                code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                message=f"Internal error: {str(e)}"
+            )]
+        )
+
+
+@FUNC.handler(path="/create_incident", method="POST")
+def create_incident_handler(req: Request, _config: Optional[Dict[str, object]], logger: Logger) -> Response:
+    """
+    Create a ServiceNow incident.
+
+    Request body:
+        - config_id: ServiceNow config ID
+        - entity_id: Entity ID to track
+        - short_description: Short description (required)
+        - assignment_group, category, description, impact, severity, state, urgency, work_notes: Optional fields
+        - custom_fields: JSON string of custom fields
+    """
+    return create_incident_impl(
+        req, logger,
+        PLUGIN_OP_ID_SERVICENOW_CREATE_INCIDENT,
+        "incident",
+        EXTERNAL_SYSTEM_ID_SERVICENOW_INCIDENT
+    )
+
+
+@FUNC.handler(path="/create_sir_incident", method="POST")
+def create_sir_incident_handler(req: Request, _config: Optional[Dict[str, object]], logger: Logger) -> Response:
+    """
+    Create a ServiceNow SIR incident.
+
+    Request body:
+        - config_id: ServiceNow config ID
+        - entity_id: Entity ID to track
+        - short_description: Short description (required)
+        - assignment_group, category, description, impact, severity, state, urgency, work_notes: Optional fields
+        - custom_fields: JSON string of custom fields
+    """
+    return create_incident_impl(
+        req, logger,
+        PLUGIN_OP_ID_SERVICENOW_CREATE_SIR_INCIDENT,
+        "sn_si_incident",
+        EXTERNAL_SYSTEM_ID_SERVICENOW_SIR_INCIDENT
+    )
+
+
+@FUNC.handler(path="/throttle", method="POST")
+def throttle_handler(req: Request, _config: Optional[Dict[str, object]], logger: Logger) -> Response:
+    """
+    Check if an action should be throttled based on deduplication store.
+
+    Request body:
+        - internal_entity_id: Internal entity ID
+        - dedup_obj_type: Deduplication object type
+        - dedup_obj_id: Deduplication object ID
+        - time_bucket: Time bucket (forever, 5 minutes, 30 minutes)
+    """
+    try:
+        logger.info(f"throttle called - trace_id: {req.trace_id}")
+
+        body = req.body
+        internal_entity_id = body.get("internal_entity_id")
+        dedup_obj_type = body.get("dedup_obj_type")
+        dedup_obj_id = body.get("dedup_obj_id")
+        time_bucket = body.get("time_bucket")
+
+        if not all([internal_entity_id, dedup_obj_type, dedup_obj_id, time_bucket]):
+            return Response(
+                code=HTTPStatus.BAD_REQUEST,
+                errors=[APIError(
+                    code=HTTPStatus.BAD_REQUEST,
+                    message="Missing required fields: internal_entity_id, dedup_obj_type, dedup_obj_id, time_bucket"
+                )]
+            )
+
+        _, api_client = create_falcon_clients(logger)
+
+        is_duplicate = check_throttling_store(
+            api_client, logger,
+            internal_entity_id, dedup_obj_type, dedup_obj_id, time_bucket
+        )
+
+        return Response(
+            code=HTTPStatus.OK,
+            body={"allowed": not is_duplicate}
+        )
+
+    except Exception as e:
+        logger.error(f"Error in throttle: {str(e)}", exc_info=True)
+        return Response(
+            code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            errors=[APIError(
+                code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                message=f"Internal error: {str(e)}"
+            )]
+        )

--- a/functions/itsmhelper/requirements.txt
+++ b/functions/itsmhelper/requirements.txt
@@ -1,0 +1,2 @@
+crowdstrike-foundry-function==1.1.3
+crowdstrike-falconpy

--- a/functions/itsmhelper/requirements.txt
+++ b/functions/itsmhelper/requirements.txt
@@ -1,2 +1,2 @@
-crowdstrike-foundry-function==1.1.3
+crowdstrike-foundry-function==1.1.4
 crowdstrike-falconpy

--- a/functions/itsmhelper/test_main.py
+++ b/functions/itsmhelper/test_main.py
@@ -1,0 +1,759 @@
+"""
+Unit tests for ServiceNow ITSM Integration Function - Python Implementation
+"""
+# pylint: disable=missing-function-docstring,too-many-lines,protected-access,wrong-import-position,import-outside-toplevel,unused-argument
+
+import json
+import unittest
+from unittest.mock import Mock, patch
+from http import HTTPStatus
+
+# Patch the FUNC.handler decorator to be a passthrough before importing main,
+# so handler functions remain callable in tests.
+import crowdstrike.foundry.function as _fdk
+
+_orig_handler = _fdk.Function.handler
+
+def _passthrough_handler(self, method, path):
+    def decorator(func):
+        _orig_handler(self, method=method, path=path)(func)
+        return func
+    return decorator
+
+_fdk.Function.handler = _passthrough_handler
+
+# Import the module under test (after patching)
+import main
+
+
+class TestSanitizeObjectKey(unittest.TestCase):
+    """Test sanitize_object_key function"""
+
+    def test_sanitize_valid_key(self):
+        result = main.sanitize_object_key("test-key.123_value")
+        self.assertEqual(result, "test-key.123_value")
+
+    def test_sanitize_invalid_characters(self):
+        result = main.sanitize_object_key("test@key#with$special%chars")
+        self.assertEqual(result, "test_key_with_special_chars")
+
+    def test_sanitize_exceeds_max_length(self):
+        long_key = "a" * 1001
+        with self.assertRaises(ValueError):
+            main.sanitize_object_key(long_key)
+
+
+class TestCreateTrackedEntityKey(unittest.TestCase):
+    """Test create_tracked_entity_key function"""
+
+    def test_create_key(self):
+        result = main.create_tracked_entity_key("servicenow", "entity123")
+        self.assertEqual(result, "servicenow.entity123")
+
+    def test_create_key_with_special_chars(self):
+        result = main.create_tracked_entity_key("service now", "entity@123")
+        self.assertEqual(result, "service_now.entity_123")
+
+
+class TestCalculateTimeBucket(unittest.TestCase):
+    """Test calculate_time_bucket function"""
+
+    def test_forever_bucket(self):
+        result = main.calculate_time_bucket(main.TIME_BUCKET_FOREVER)
+        self.assertEqual(result, "forever_bucket")
+
+    @patch('main.datetime')
+    def test_five_min_bucket(self, mock_datetime):
+        from datetime import datetime, timezone
+        # Mock current time to 2024-01-15 10:23:45
+        mock_now = datetime(2024, 1, 15, 10, 23, 45, tzinfo=timezone.utc)
+        mock_datetime.now.return_value = mock_now
+
+        result = main.calculate_time_bucket(main.TIME_BUCKET_FIVE_MIN)
+        # Should round down to 10:20 and format as "2024-01-15_10:20"
+        self.assertEqual(result, "2024-01-15_10:20")
+
+    @patch('main.datetime')
+    def test_thirty_min_bucket(self, mock_datetime):
+        from datetime import datetime, timezone
+        # Mock current time to 2024-01-15 10:23:45
+        mock_now = datetime(2024, 1, 15, 10, 23, 45, tzinfo=timezone.utc)
+        mock_datetime.now.return_value = mock_now
+
+        result = main.calculate_time_bucket(main.TIME_BUCKET_THIRTY_MIN)
+        # Should round down to 10:00 and format as "2024-01-15_10:00"
+        self.assertEqual(result, "2024-01-15_10:00")
+
+    def test_invalid_bucket(self):
+        with self.assertRaises(ValueError):
+            main.calculate_time_bucket("invalid_bucket")
+
+
+class TestCheckExternalEntityExists(unittest.TestCase):
+    """Test check_external_entity_exists function"""
+
+    def test_entity_exists(self):
+        mock_client = Mock()
+        mock_logger = Mock()
+
+        # Mock successful response (bytes)
+        entity_record = {
+            "internal_entity_id": "entity123",
+            "external_entity_id": "ext123",
+            "external_system_id": "servicenow_incident"
+        }
+        mock_client.command.return_value = json.dumps(entity_record).encode('utf-8')
+
+        exists, record = main.check_external_entity_exists(
+            mock_client, mock_logger, "entity123", "servicenow_incident"
+        )
+
+        self.assertTrue(exists)
+        self.assertEqual(record["external_entity_id"], "ext123")
+        mock_client.command.assert_called_once_with(
+            "GetObject",
+            collection_name=main.COLLECTION_NAME_TRACKED_ENTITIES,
+            object_key="servicenow_incident.entity123"
+        )
+
+    def test_entity_not_exists_404_dict(self):
+        """SDK returns error dict (404 or masked 404) — treated as not found."""
+        mock_client = Mock()
+        mock_logger = Mock()
+
+        mock_client.command.return_value = {"status_code": 404, "headers": {}, "body": {"errors": [], "resources": []}}
+
+        exists, record = main.check_external_entity_exists(
+            mock_client, mock_logger, "entity123", "servicenow_incident"
+        )
+
+        self.assertFalse(exists)
+        self.assertIsNone(record)
+
+    def test_entity_not_exists_500(self):
+        """GetObject returns error dict with 500 — treated as not found."""
+        mock_client = Mock()
+        mock_logger = Mock()
+
+        mock_client.command.return_value = {
+            "status_code": 500, "headers": {},
+            "body": {"errors": [{"message": "'bytes' object has no attribute 'get'"}], "resources": []}
+        }
+
+        exists, record = main.check_external_entity_exists(
+            mock_client, mock_logger, "entity123", "servicenow_incident"
+        )
+
+        self.assertFalse(exists)
+        self.assertIsNone(record)
+
+    def test_entity_exists_but_wrong_system_id(self):
+        mock_client = Mock()
+        mock_logger = Mock()
+
+        # Mock response with different system ID
+        entity_record = {
+            "internal_entity_id": "entity123",
+            "external_entity_id": "ext123",
+            "external_system_id": "other_system"
+        }
+        mock_client.command.return_value = json.dumps(entity_record).encode('utf-8')
+
+        exists, record = main.check_external_entity_exists(
+            mock_client, mock_logger, "entity123", "servicenow_incident"
+        )
+
+        self.assertFalse(exists)
+        self.assertIsNone(record)
+
+
+class TestCreateOrUpdateExternalEntityMapping(unittest.TestCase):
+    """Test create_or_update_external_entity_mapping function"""
+
+    def test_create_mapping_success(self):
+        mock_client = Mock()
+        mock_logger = Mock()
+
+        # Mock successful PutObject response
+        mock_client.command.return_value = {"status_code": 201}
+
+        main.create_or_update_external_entity_mapping(
+            mock_client, mock_logger,
+            "entity123", "ext123", "servicenow_incident"
+        )
+
+        # Verify command was called with correct args
+        mock_client.command.assert_called_once()
+        call_args = mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "PutObject")
+        self.assertEqual(call_args[1]["body"]["internal_entity_id"], "entity123")
+        self.assertEqual(call_args[1]["body"]["external_entity_id"], "ext123")
+        self.assertEqual(call_args[1]["body"]["external_system_id"], "servicenow_incident")
+
+    def test_create_mapping_failure(self):
+        mock_client = Mock()
+        mock_logger = Mock()
+
+        # Mock failed PutObject response
+        mock_client.command.return_value = {"status_code": 500}
+
+        with self.assertRaises(main.StorageError):
+            main.create_or_update_external_entity_mapping(
+                mock_client, mock_logger,
+                "entity123", "ext123", "servicenow_incident"
+            )
+
+
+class TestCheckThrottlingStore(unittest.TestCase):
+    """Test check_throttling_store function"""
+
+    def test_first_occurrence_creates_record(self):
+        mock_client = Mock()
+        mock_logger = Mock()
+
+        # GetObject returns 404 dict (not found), PutObject succeeds
+        mock_client.command.side_effect = [
+            {"status_code": 404, "headers": {}, "body": {"errors": [], "resources": []}},
+            {"status_code": 201}
+        ]
+
+        is_duplicate = main.check_throttling_store(
+            mock_client, mock_logger,
+            "entity123", "detection", "det456", main.TIME_BUCKET_FOREVER
+        )
+
+        self.assertFalse(is_duplicate)
+        self.assertEqual(mock_client.command.call_count, 2)
+
+    def test_first_occurrence_500_creates_record(self):
+        """GetObject returns 500 error dict — still creates new record."""
+        mock_client = Mock()
+        mock_logger = Mock()
+
+        # GetObject returns 500 error dict, PutObject succeeds
+        mock_client.command.side_effect = [
+            {
+                "status_code": 500, "headers": {},
+                "body": {"errors": [{"message": "'bytes' object has no attribute 'get'"}], "resources": []}
+            },
+            {"status_code": 201}
+        ]
+
+        is_duplicate = main.check_throttling_store(
+            mock_client, mock_logger,
+            "entity123", "detection", "det456", main.TIME_BUCKET_FOREVER
+        )
+
+        self.assertFalse(is_duplicate)
+        self.assertEqual(mock_client.command.call_count, 2)
+
+    def test_duplicate_occurrence(self):
+        mock_client = Mock()
+        mock_logger = Mock()
+
+        # GetObject succeeds (record exists as bytes)
+        dedup_record = {"time_bucket": main.TIME_BUCKET_FOREVER}
+        mock_client.command.return_value = json.dumps(dedup_record).encode('utf-8')
+
+        is_duplicate = main.check_throttling_store(
+            mock_client, mock_logger,
+            "entity123", "detection", "det456", main.TIME_BUCKET_FOREVER
+        )
+
+        self.assertTrue(is_duplicate)
+        # Should only call GetObject, not PutObject
+        self.assertEqual(mock_client.command.call_count, 1)
+
+    def test_invalid_time_bucket(self):
+        mock_client = Mock()
+        mock_logger = Mock()
+
+        with self.assertRaises(ValueError):
+            main.check_throttling_store(
+                mock_client, mock_logger,
+                "entity123", "detection", "det456", "invalid"
+            )
+
+
+class TestBuildRequestPayload(unittest.TestCase):
+    """Test build_request_payload function"""
+
+    def test_minimal_payload(self):
+        body = {"short_description": "Test incident"}
+        result = main.build_request_payload(body)
+
+        self.assertEqual(result["short_description"], "Test incident")
+        self.assertEqual(len(result), 1)
+
+    def test_full_payload(self):
+        body = {
+            "short_description": "Test incident",
+            "assignment_group": "IT Support",
+            "category": "Software",
+            "description": "Full description",
+            "impact": "2",
+            "severity": "3",
+            "state": "1",
+            "urgency": "2",
+            "work_notes": "Initial notes"
+        }
+        result = main.build_request_payload(body)
+
+        self.assertEqual(len(result), 9)
+        self.assertEqual(result["assignment_group"], "IT Support")
+        self.assertEqual(result["impact"], "2")
+
+    def test_payload_with_custom_fields(self):
+        body = {
+            "short_description": "Test incident",
+            "custom_fields": '{"custom_field1": "value1", "custom_field2": "value2"}'
+        }
+        result = main.build_request_payload(body)
+
+        self.assertEqual(result["short_description"], "Test incident")
+        self.assertEqual(result["custom_field1"], "value1")
+        self.assertEqual(result["custom_field2"], "value2")
+
+
+class TestCheckIfExtEntityExistsHandler(unittest.TestCase):
+    """Test check_if_ext_entity_exists_handler"""
+
+    @patch('main.create_falcon_clients')
+    @patch('main.check_external_entity_exists')
+    def test_entity_exists(self, mock_check, mock_create_clients):
+        mock_logger = Mock()
+        mock_client = Mock()
+        mock_create_clients.return_value = (Mock(), mock_client)
+
+        # Mock entity exists
+        mock_check.return_value = (True, {
+            "external_entity_id": "ext123",
+            "external_system_id": "servicenow_incident"
+        })
+
+        mock_request = Mock()
+        mock_request.trace_id = "trace-123"
+        mock_request.body = {
+            "internal_entity_id": "entity123",
+            "external_system_id": "servicenow_incident"
+        }
+
+        response = main.check_if_ext_entity_exists_handler(mock_request, None, mock_logger)
+
+        self.assertEqual(response.code, HTTPStatus.OK)
+        self.assertTrue(response.body["exists"])
+        self.assertEqual(response.body["ext_id"], "ext123")
+
+    @patch('main.create_falcon_clients')
+    def test_entity_not_exists_404(self, mock_create_clients):
+        """Entity doesn't exist (404) returns exists=false with HTTP 200."""
+        mock_logger = Mock()
+        mock_client = Mock()
+        mock_create_clients.return_value = (Mock(), mock_client)
+
+        # GetObject returns error dict (500 response)
+        mock_client.command.return_value = {
+            "status_code": 500, "headers": {},
+            "body": {"errors": [{"message": "'bytes' object has no attribute 'get'"}], "resources": []}
+        }
+
+        mock_request = Mock()
+        mock_request.trace_id = "trace-123"
+        mock_request.body = {
+            "internal_entity_id": "entity123",
+            "external_system_id": "servicenow_incident"
+        }
+
+        response = main.check_if_ext_entity_exists_handler(mock_request, None, mock_logger)
+
+        self.assertEqual(response.code, HTTPStatus.OK)
+        self.assertFalse(response.body["exists"])
+
+    @patch('main.create_falcon_clients')
+    @patch('main.check_external_entity_exists')
+    def test_entity_not_exists(self, mock_check, mock_create_clients):
+        mock_logger = Mock()
+        mock_client = Mock()
+        mock_create_clients.return_value = (Mock(), mock_client)
+
+        # Mock entity does not exist
+        mock_check.return_value = (False, None)
+
+        mock_request = Mock()
+        mock_request.trace_id = "trace-123"
+        mock_request.body = {
+            "internal_entity_id": "entity123",
+            "external_system_id": "servicenow_incident"
+        }
+
+        response = main.check_if_ext_entity_exists_handler(mock_request, None, mock_logger)
+
+        self.assertEqual(response.code, HTTPStatus.OK)
+        self.assertFalse(response.body["exists"])
+
+    def test_missing_required_fields(self):
+        mock_logger = Mock()
+        mock_request = Mock()
+        mock_request.trace_id = "trace-123"
+        mock_request.body = {"internal_entity_id": "entity123"}  # Missing external_system_id
+
+        response = main.check_if_ext_entity_exists_handler(mock_request, None, mock_logger)
+
+        self.assertEqual(response.code, HTTPStatus.BAD_REQUEST)
+        self.assertTrue(len(response.errors) > 0)
+
+
+class TestCreateEntityMappingHandler(unittest.TestCase):
+    """Test create_entity_mapping_handler"""
+
+    @patch('main.create_falcon_clients')
+    @patch('main.create_or_update_external_entity_mapping')
+    def test_create_mapping_success(self, mock_create_mapping, mock_create_clients):
+        mock_logger = Mock()
+        mock_client = Mock()
+        mock_create_clients.return_value = (Mock(), mock_client)
+
+        mock_request = Mock()
+        mock_request.trace_id = "trace-123"
+        mock_request.body = {
+            "internal_entity_id": "entity123",
+            "external_entity_id": "ext123",
+            "external_system_id": "servicenow_incident"
+        }
+
+        response = main.create_entity_mapping_handler(mock_request, None, mock_logger)
+
+        self.assertEqual(response.code, HTTPStatus.CREATED)
+        self.assertEqual(response.body["internal_entity_id"], "entity123")
+        self.assertEqual(response.body["external_entity_id"], "ext123")
+        mock_create_mapping.assert_called_once()
+
+    def test_missing_required_fields(self):
+        mock_logger = Mock()
+        mock_request = Mock()
+        mock_request.trace_id = "trace-123"
+        mock_request.body = {
+            "internal_entity_id": "entity123",
+            "external_entity_id": "ext123"
+            # Missing external_system_id
+        }
+
+        response = main.create_entity_mapping_handler(mock_request, None, mock_logger)
+
+        self.assertEqual(response.code, HTTPStatus.BAD_REQUEST)
+
+
+class TestCreateIncidentHandlers(unittest.TestCase):
+    """Test create_incident_handler and create_sir_incident_handler"""
+
+    @patch('main.create_falcon_clients')
+    @patch('main.check_external_entity_exists')
+    def test_incident_already_exists(self, mock_check, mock_create_clients):
+        mock_logger = Mock()
+        mock_api_integrations = Mock()
+        mock_client = Mock()
+        mock_create_clients.return_value = (mock_api_integrations, mock_client)
+
+        # Mock that ticket already exists
+        mock_check.return_value = (True, {
+            "external_entity_id": "existing-ticket-123"
+        })
+
+        mock_request = Mock()
+        mock_request.trace_id = "trace-123"
+        mock_request.body = {
+            "config_id": "config123",
+            "entity_id": "entity123",
+            "short_description": "Test incident"
+        }
+
+        response = main.create_incident_handler(mock_request, None, mock_logger)
+
+        self.assertEqual(response.code, HTTPStatus.OK)
+        self.assertTrue(response.body["exists"])
+        self.assertEqual(response.body["ticket_id"], "existing-ticket-123")
+        # Should not call API integration if ticket exists
+        mock_api_integrations.execute_command.assert_not_called()
+
+    @patch('main.create_falcon_clients')
+    @patch('main.check_external_entity_exists')
+    @patch('main.create_or_update_external_entity_mapping')
+    def test_create_new_incident(self, mock_create_mapping, mock_check, mock_create_clients):
+        mock_logger = Mock()
+        mock_api_integrations = Mock()
+        mock_client = Mock()
+        mock_create_clients.return_value = (mock_api_integrations, mock_client)
+
+        # Mock that ticket does not exist
+        mock_check.return_value = (False, None)
+
+        # Mock successful API integration response
+        mock_api_integrations.execute_command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [{
+                    "response_body": {
+                        "result": {
+                            "sys_id": "new-ticket-123",
+                            "sys_class_name": "incident"
+                        }
+                    }
+                }]
+            }
+        }
+
+        mock_request = Mock()
+        mock_request.trace_id = "trace-123"
+        mock_request.body = {
+            "config_id": "config123",
+            "entity_id": "entity123",
+            "short_description": "Test incident",
+            "impact": "2",
+            "urgency": "2"
+        }
+
+        response = main.create_incident_handler(mock_request, None, mock_logger)
+
+        self.assertEqual(response.code, HTTPStatus.CREATED)
+        self.assertFalse(response.body["exists"])
+        self.assertEqual(response.body["ticket_id"], "new-ticket-123")
+        self.assertEqual(response.body["ticket_type"], "incident")
+
+        # Verify API integration was called
+        mock_api_integrations.execute_command.assert_called_once()
+        call_args = mock_api_integrations.execute_command.call_args[1]
+        self.assertEqual(call_args["body"]["resources"][0]["definition_id"], main.PLUGIN_DEF_ID_SERVICENOW)
+
+        # Verify entity mapping was created
+        mock_create_mapping.assert_called_once()
+
+    @patch('main.create_falcon_clients')
+    @patch('main.create_or_update_external_entity_mapping')
+    def test_create_new_incident_entity_404(self, mock_create_mapping, mock_create_clients):
+        """Entity check returns 404, triggers new ticket creation via ServiceNow."""
+        mock_logger = Mock()
+        mock_api_integrations = Mock()
+        mock_client = Mock()
+        mock_create_clients.return_value = (mock_api_integrations, mock_client)
+
+        # GetObject returns 404 on entity check, PutObject succeeds for mapping
+        mock_client.command.side_effect = [
+            {"status_code": 404, "headers": {}, "body": {"errors": [], "resources": []}},  # check_external_entity_exists
+            {"status_code": 201}  # create_or_update → PutObject
+        ]
+
+        # Mock successful ServiceNow response
+        mock_api_integrations.execute_command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [{
+                    "response_body": {
+                        "result": {
+                            "sys_id": "new-ticket-456",
+                            "sys_class_name": "incident"
+                        }
+                    }
+                }]
+            }
+        }
+
+        mock_request = Mock()
+        mock_request.trace_id = "trace-123"
+        mock_request.context = {}
+        mock_request.body = {
+            "config_id": "config123",
+            "entity_id": "entity123",
+            "short_description": "Test incident"
+        }
+
+        response = main.create_incident_impl(
+            mock_request, mock_logger,
+            main.PLUGIN_OP_ID_SERVICENOW_CREATE_INCIDENT,
+            "incident",
+            main.EXTERNAL_SYSTEM_ID_SERVICENOW_INCIDENT
+        )
+
+        self.assertEqual(response.code, HTTPStatus.CREATED)
+        self.assertFalse(response.body["exists"])
+        self.assertEqual(response.body["ticket_id"], "new-ticket-456")
+        mock_api_integrations.execute_command.assert_called_once()
+
+    @patch('main.create_falcon_clients')
+    @patch('main.check_external_entity_exists')
+    def test_execute_command_failure(self, mock_check, mock_create_clients):
+        mock_logger = Mock()
+        mock_api_integrations = Mock()
+        mock_client = Mock()
+        mock_create_clients.return_value = (mock_api_integrations, mock_client)
+
+        mock_check.return_value = (False, None)
+
+        # Mock failed execute_command response
+        mock_api_integrations.execute_command.return_value = {
+            "status_code": 403,
+            "body": {
+                "errors": [{"message": "received invalid status code from plugin: 403"}]
+            }
+        }
+
+        mock_request = Mock()
+        mock_request.trace_id = "trace-123"
+        mock_request.body = {
+            "config_id": "config123",
+            "entity_id": "entity123",
+            "short_description": "Test incident"
+        }
+
+        response = main.create_incident_handler(mock_request, None, mock_logger)
+
+        self.assertEqual(response.code, HTTPStatus.INTERNAL_SERVER_ERROR)
+        self.assertIn("403", response.errors[0].message)
+
+    @patch('main.create_falcon_clients')
+    @patch('main.check_external_entity_exists')
+    def test_servicenow_error_response(self, mock_check, mock_create_clients):
+        mock_logger = Mock()
+        mock_api_integrations = Mock()
+        mock_client = Mock()
+        mock_create_clients.return_value = (mock_api_integrations, mock_client)
+
+        # Mock that ticket does not exist
+        mock_check.return_value = (False, None)
+
+        # Mock ServiceNow error response
+        mock_api_integrations.execute_command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [{
+                    "response_body": {
+                        "error": "ServiceNow validation error"
+                    }
+                }]
+            }
+        }
+
+        mock_request = Mock()
+        mock_request.trace_id = "trace-123"
+        mock_request.body = {
+            "config_id": "config123",
+            "entity_id": "entity123",
+            "short_description": "Test incident"
+        }
+
+        response = main.create_incident_handler(mock_request, None, mock_logger)
+
+        self.assertEqual(response.code, HTTPStatus.INTERNAL_SERVER_ERROR)
+        self.assertTrue(len(response.errors) > 0)
+        self.assertIn("ServiceNow Error", response.errors[0].message)
+
+    def test_missing_required_fields(self):
+        mock_logger = Mock()
+        mock_request = Mock()
+        mock_request.trace_id = "trace-123"
+        mock_request.body = {
+            "config_id": "config123"
+            # Missing entity_id
+        }
+
+        response = main.create_incident_handler(mock_request, None, mock_logger)
+
+        self.assertEqual(response.code, HTTPStatus.BAD_REQUEST)
+
+
+class TestThrottleHandler(unittest.TestCase):
+    """Test throttle_handler"""
+
+    @patch('main.create_falcon_clients')
+    @patch('main.check_throttling_store')
+    def test_action_allowed(self, mock_check_throttle, mock_create_clients):
+        mock_logger = Mock()
+        mock_client = Mock()
+        mock_create_clients.return_value = (Mock(), mock_client)
+
+        # Mock that it's not a duplicate
+        mock_check_throttle.return_value = False
+
+        mock_request = Mock()
+        mock_request.trace_id = "trace-123"
+        mock_request.body = {
+            "internal_entity_id": "entity123",
+            "dedup_obj_type": "detection",
+            "dedup_obj_id": "det456",
+            "time_bucket": "forever"
+        }
+
+        response = main.throttle_handler(mock_request, None, mock_logger)
+
+        self.assertEqual(response.code, HTTPStatus.OK)
+        self.assertTrue(response.body["allowed"])
+
+    @patch('main.create_falcon_clients')
+    def test_action_allowed_on_404(self, mock_create_clients):
+        """Record doesn't exist (404) creates new record and allows action."""
+        mock_logger = Mock()
+        mock_client = Mock()
+        mock_create_clients.return_value = (Mock(), mock_client)
+
+        # GetObject returns 404, PutObject succeeds
+        mock_client.command.side_effect = [
+            {"status_code": 404, "headers": {}, "body": {"errors": [], "resources": []}},  # GetObject → not found
+            {"status_code": 201}  # PutObject → created
+        ]
+
+        mock_request = Mock()
+        mock_request.trace_id = "trace-123"
+        mock_request.body = {
+            "internal_entity_id": "entity123",
+            "dedup_obj_type": "detection",
+            "dedup_obj_id": "det456",
+            "time_bucket": "forever"
+        }
+
+        response = main.throttle_handler(mock_request, None, mock_logger)
+
+        self.assertEqual(response.code, HTTPStatus.OK)
+        self.assertTrue(response.body["allowed"])
+        # Should have called GetObject then PutObject
+        self.assertEqual(mock_client.command.call_count, 2)
+
+    @patch('main.create_falcon_clients')
+    @patch('main.check_throttling_store')
+    def test_action_not_allowed(self, mock_check_throttle, mock_create_clients):
+        mock_logger = Mock()
+        mock_client = Mock()
+        mock_create_clients.return_value = (Mock(), mock_client)
+
+        # Mock that it's a duplicate
+        mock_check_throttle.return_value = True
+
+        mock_request = Mock()
+        mock_request.trace_id = "trace-123"
+        mock_request.body = {
+            "internal_entity_id": "entity123",
+            "dedup_obj_type": "detection",
+            "dedup_obj_id": "det456",
+            "time_bucket": "forever"
+        }
+
+        response = main.throttle_handler(mock_request, None, mock_logger)
+
+        self.assertEqual(response.code, HTTPStatus.OK)
+        self.assertFalse(response.body["allowed"])
+
+    def test_missing_required_fields(self):
+        mock_logger = Mock()
+        mock_request = Mock()
+        mock_request.trace_id = "trace-123"
+        mock_request.body = {
+            "internal_entity_id": "entity123",
+            "dedup_obj_type": "detection"
+            # Missing dedup_obj_id and time_bucket
+        }
+
+        response = main.throttle_handler(mock_request, None, mock_logger)
+
+        self.assertEqual(response.code, HTTPStatus.BAD_REQUEST)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/manifest.yml
+++ b/manifest.yml
@@ -9,6 +9,17 @@ ignored:
   - e2e
   - e2e/.+
   - run-e2e-local\.sh
+  - venv
+  - .*/venv/.*
+  - htmlcov
+  - .*/htmlcov/.*
+  - .*\.pyc$
+  - __pycache__
+  - .*/__pycache__/.*
+  - \.pytest_cache
+  - .*/\.pytest_cache/.*
+  - \.coverage$
+  - .*/test_.*\.py$
 ui:
   homepage: ""
   extensions: []
@@ -113,6 +124,8 @@ functions:
           tags:
             - ServiceNow Foundry
         permissions: []
+    # Change to 'python' for the Python implementation (using falconpy)
+    # Both main.py (Python) and main.go (Go) exist in the same directory
     language: go
 workflows: []
 parsers: []


### PR DESCRIPTION
Alternative Python implementation using `falconpy` SDK:
  - All 5 endpoints match the Go version: entity check, entity mapping, incident creation, SIR incident creation, throttling
  - 38 unit tests, pylint 10/10
  - CI workflow for Python linting

Test plan
  - Unit tests (38/38)
  - Deployed and verified in Foundry runtime