### PR TITLE
Migrate collection operations from APIHarnessV2 to CustomStorage

### DIFF
--- a/functions/itsmhelper/main.py
+++ b/functions/itsmhelper/main.py
@@ -378,10 +378,10 @@ def check_if_ext_entity_exists_handler(req: Request, _config: Optional[Dict[str,
                 )]
             )
 
-        _, api_client = create_falcon_clients(logger)
+        _, custom_storage = create_falcon_clients(logger)
 
         exists, ext_record = check_external_entity_exists(
-            api_client, logger, internal_entity_id, external_system_id
+            custom_storage, logger, internal_entity_id, external_system_id
         )
 
         if not exists:
@@ -437,10 +437,10 @@ def create_entity_mapping_handler(req: Request, _config: Optional[Dict[str, obje
                 )]
             )
 
-        _, api_client = create_falcon_clients(logger)
+        _, custom_storage = create_falcon_clients(logger)
 
         create_or_update_external_entity_mapping(
-            api_client, logger,
+            custom_storage, logger,
             internal_entity_id, external_entity_id, external_system_id
         )
 
@@ -503,11 +503,11 @@ def create_incident_impl(  # pylint: disable=too-many-locals,too-many-return-sta
                 )]
             )
 
-        api_integrations, api_client = create_falcon_clients(logger)
+        api_integrations, custom_storage = create_falcon_clients(logger)
 
         # Check if ticket already exists
         exists, ext_record = check_external_entity_exists(
-            api_client, logger, entity_id, external_system_id
+            custom_storage, logger, entity_id, external_system_id
         )
 
         if exists:
@@ -591,7 +591,7 @@ def create_incident_impl(  # pylint: disable=too-many-locals,too-many-return-sta
         # Store entity mapping
         if snow_sys_id:
             create_or_update_external_entity_mapping(
-                api_client, logger,
+                custom_storage, logger,
                 entity_id, snow_sys_id, external_system_id
             )
 
@@ -684,10 +684,10 @@ def throttle_handler(req: Request, _config: Optional[Dict[str, object]], logger:
                 )]
             )
 
-        _, api_client = create_falcon_clients(logger)
+        _, custom_storage = create_falcon_clients(logger)
 
         is_duplicate = check_throttling_store(
-            api_client, logger,
+            custom_storage, logger,
             internal_entity_id, dedup_obj_type, dedup_obj_id, time_bucket
         )
 

--- a/functions/itsmhelper/main.py
+++ b/functions/itsmhelper/main.py
@@ -81,9 +81,9 @@ def create_falcon_clients(logger: Logger) -> Tuple[APIIntegrations, CustomStorag
     """
     try:
         api_integrations = APIIntegrations()
-        collections = CustomStorage()
+        custom_storage = CustomStorage()
 
-        return api_integrations, collections
+        return api_integrations, custom_storage
 
     except Exception as e:
         logger.error(f"Error creating Falcon clients: {str(e)}", exc_info=True)
@@ -162,7 +162,7 @@ def calculate_time_bucket(time_bucket: str) -> str:
 
 
 def check_external_entity_exists(
-    collections: CustomStorage,
+    custom_storage: CustomStorage,
     _logger: Logger,
     internal_entity_id: str,
     external_system_id: str
@@ -171,7 +171,7 @@ def check_external_entity_exists(
     Check if an external entity mapping exists.
 
     Args:
-        collections: CustomStorage client
+        custom_storage: CustomStorage client
         logger: Logger instance
         internal_entity_id: Internal entity ID
         external_system_id: External system ID
@@ -181,7 +181,7 @@ def check_external_entity_exists(
     """
     key = create_tracked_entity_key(external_system_id, internal_entity_id)
 
-    response = collections.GetObject(
+    response = custom_storage.GetObject(
         collection_name=COLLECTION_NAME_TRACKED_ENTITIES,
         object_key=key
     )
@@ -200,7 +200,7 @@ def check_external_entity_exists(
 
 
 def create_or_update_external_entity_mapping(
-    collections: CustomStorage,
+    custom_storage: CustomStorage,
     logger: Logger,
     internal_entity_id: str,
     external_entity_id: str,
@@ -210,7 +210,7 @@ def create_or_update_external_entity_mapping(
     Create or update an external entity mapping.
 
     Args:
-        collections: CustomStorage client
+        custom_storage: CustomStorage client
         logger: Logger instance
         internal_entity_id: Internal entity ID
         external_entity_id: External entity ID
@@ -225,7 +225,7 @@ def create_or_update_external_entity_mapping(
             "external_system_id": external_system_id
         }
 
-        response = collections.PutObject(
+        response = custom_storage.PutObject(
             collection_name=COLLECTION_NAME_TRACKED_ENTITIES,
             object_key=key,
             body=record
@@ -250,7 +250,7 @@ def create_or_update_external_entity_mapping(
 
 
 def check_throttling_store(  # pylint: disable=too-many-arguments,too-many-positional-arguments
-    collections: CustomStorage,
+    custom_storage: CustomStorage,
     logger: Logger,
     internal_entity_id: str,
     dedup_obj_type: str,
@@ -261,7 +261,7 @@ def check_throttling_store(  # pylint: disable=too-many-arguments,too-many-posit
     Check if a combination of IDs already exists in throttling store.
 
     Args:
-        collections: CustomStorage client
+        custom_storage: CustomStorage client
         logger: Logger instance
         internal_entity_id: Internal entity ID
         dedup_obj_type: Deduplication object type
@@ -286,7 +286,7 @@ def check_throttling_store(  # pylint: disable=too-many-arguments,too-many-posit
     dedup_key = hashlib.md5(combined.encode()).hexdigest()
 
     # Try to get the object — success means duplicate exists
-    response = collections.GetObject(
+    response = custom_storage.GetObject(
         collection_name=COLLECTION_NAME_DEDUP_STORE,
         object_key=dedup_key
     )
@@ -303,7 +303,7 @@ def check_throttling_store(  # pylint: disable=too-many-arguments,too-many-posit
 
     # Store new dedup record
     new_record = {"time_bucket": time_bucket}
-    response = collections.PutObject(
+    response = custom_storage.PutObject(
         collection_name=COLLECTION_NAME_DEDUP_STORE,
         object_key=dedup_key,
         body=new_record

--- a/functions/itsmhelper/main.py
+++ b/functions/itsmhelper/main.py
@@ -27,7 +27,7 @@ from typing import Dict, Any, Optional, Tuple
 from http import HTTPStatus
 
 from crowdstrike.foundry.function import Function, Request, Response, APIError
-from falconpy import APIIntegrations, APIHarnessV2
+from falconpy import APIIntegrations, CustomStorage
 
 # Initialize the function instance
 FUNC = Function.instance()
@@ -63,7 +63,7 @@ class FalconClientError(ITSMError):
     """Exception for Falcon client errors."""
 
 
-def create_falcon_clients(logger: Logger) -> Tuple[APIIntegrations, APIHarnessV2]:
+def create_falcon_clients(logger: Logger) -> Tuple[APIIntegrations, CustomStorage]:
     """
     Create Falcon API clients.
 
@@ -74,16 +74,16 @@ def create_falcon_clients(logger: Logger) -> Tuple[APIIntegrations, APIHarnessV2
         logger: Logger instance for logging
 
     Returns:
-        Tuple of (APIIntegrations client, APIHarnessV2 client)
+        Tuple of (APIIntegrations client, CustomStorage client)
 
     Raises:
         FalconClientError: If client creation fails
     """
     try:
         api_integrations = APIIntegrations()
-        api_client = APIHarnessV2()
+        collections = CustomStorage()
 
-        return api_integrations, api_client
+        return api_integrations, collections
 
     except Exception as e:
         logger.error(f"Error creating Falcon clients: {str(e)}", exc_info=True)
@@ -162,7 +162,7 @@ def calculate_time_bucket(time_bucket: str) -> str:
 
 
 def check_external_entity_exists(
-    api_client: APIHarnessV2,
+    collections: CustomStorage,
     _logger: Logger,
     internal_entity_id: str,
     external_system_id: str
@@ -171,7 +171,7 @@ def check_external_entity_exists(
     Check if an external entity mapping exists.
 
     Args:
-        api_client: APIHarnessV2 client
+        collections: CustomStorage client
         logger: Logger instance
         internal_entity_id: Internal entity ID
         external_system_id: External system ID
@@ -181,14 +181,12 @@ def check_external_entity_exists(
     """
     key = create_tracked_entity_key(external_system_id, internal_entity_id)
 
-    response = api_client.command(
-        "GetObject",
+    response = collections.GetObject(
         collection_name=COLLECTION_NAME_TRACKED_ENTITIES,
         object_key=key
     )
 
     # GetObject returns bytes on success, dict on error.
-    # Decode attempt distinguishes success from any error.
     try:
         ext_record = json.loads(response.decode('utf-8'))
     except (AttributeError, UnicodeDecodeError, json.JSONDecodeError):
@@ -202,7 +200,7 @@ def check_external_entity_exists(
 
 
 def create_or_update_external_entity_mapping(
-    api_client: APIHarnessV2,
+    collections: CustomStorage,
     logger: Logger,
     internal_entity_id: str,
     external_entity_id: str,
@@ -212,7 +210,7 @@ def create_or_update_external_entity_mapping(
     Create or update an external entity mapping.
 
     Args:
-        api_client: APIHarnessV2 client
+        collections: CustomStorage client
         logger: Logger instance
         internal_entity_id: Internal entity ID
         external_entity_id: External entity ID
@@ -227,8 +225,7 @@ def create_or_update_external_entity_mapping(
             "external_system_id": external_system_id
         }
 
-        response = api_client.command(
-            "PutObject",
+        response = collections.PutObject(
             collection_name=COLLECTION_NAME_TRACKED_ENTITIES,
             object_key=key,
             body=record
@@ -253,7 +250,7 @@ def create_or_update_external_entity_mapping(
 
 
 def check_throttling_store(  # pylint: disable=too-many-arguments,too-many-positional-arguments
-    api_client: APIHarnessV2,
+    collections: CustomStorage,
     logger: Logger,
     internal_entity_id: str,
     dedup_obj_type: str,
@@ -264,7 +261,7 @@ def check_throttling_store(  # pylint: disable=too-many-arguments,too-many-posit
     Check if a combination of IDs already exists in throttling store.
 
     Args:
-        api_client: APIHarnessV2 client
+        collections: CustomStorage client
         logger: Logger instance
         internal_entity_id: Internal entity ID
         dedup_obj_type: Deduplication object type
@@ -289,14 +286,12 @@ def check_throttling_store(  # pylint: disable=too-many-arguments,too-many-posit
     dedup_key = hashlib.md5(combined.encode()).hexdigest()
 
     # Try to get the object — success means duplicate exists
-    response = api_client.command(
-        "GetObject",
+    response = collections.GetObject(
         collection_name=COLLECTION_NAME_DEDUP_STORE,
         object_key=dedup_key
     )
 
     # GetObject returns bytes on success, dict on error.
-    # Decode attempt distinguishes success from any error.
     try:
         json.loads(response.decode('utf-8'))
         return True  # Record exists, it's a duplicate
@@ -308,8 +303,7 @@ def check_throttling_store(  # pylint: disable=too-many-arguments,too-many-posit
 
     # Store new dedup record
     new_record = {"time_bucket": time_bucket}
-    response = api_client.command(
-        "PutObject",
+    response = collections.PutObject(
         collection_name=COLLECTION_NAME_DEDUP_STORE,
         object_key=dedup_key,
         body=new_record

--- a/functions/itsmhelper/test_main.py
+++ b/functions/itsmhelper/test_main.py
@@ -96,13 +96,13 @@ class TestCheckExternalEntityExists(unittest.TestCase):
         mock_client = Mock()
         mock_logger = Mock()
 
-        # Mock successful response (bytes)
+        # Mock successful response (bytes on success)
         entity_record = {
             "internal_entity_id": "entity123",
             "external_entity_id": "ext123",
             "external_system_id": "servicenow_incident"
         }
-        mock_client.command.return_value = json.dumps(entity_record).encode('utf-8')
+        mock_client.GetObject.return_value = json.dumps(entity_record).encode('utf-8')
 
         exists, record = main.check_external_entity_exists(
             mock_client, mock_logger, "entity123", "servicenow_incident"
@@ -110,18 +110,17 @@ class TestCheckExternalEntityExists(unittest.TestCase):
 
         self.assertTrue(exists)
         self.assertEqual(record["external_entity_id"], "ext123")
-        mock_client.command.assert_called_once_with(
-            "GetObject",
+        mock_client.GetObject.assert_called_once_with(
             collection_name=main.COLLECTION_NAME_TRACKED_ENTITIES,
             object_key="servicenow_incident.entity123"
         )
 
-    def test_entity_not_exists_404_dict(self):
-        """SDK returns error dict (404 or masked 404) — treated as not found."""
+    def test_entity_not_exists_404(self):
+        """GetObject returns error dict on 404 — treated as not found."""
         mock_client = Mock()
         mock_logger = Mock()
 
-        mock_client.command.return_value = {"status_code": 404, "headers": {}, "body": {"errors": [], "resources": []}}
+        mock_client.GetObject.return_value = {"status_code": 404, "headers": {}, "body": {"errors": [], "resources": []}}
 
         exists, record = main.check_external_entity_exists(
             mock_client, mock_logger, "entity123", "servicenow_incident"
@@ -131,13 +130,13 @@ class TestCheckExternalEntityExists(unittest.TestCase):
         self.assertIsNone(record)
 
     def test_entity_not_exists_500(self):
-        """GetObject returns error dict with 500 — treated as not found."""
+        """GetObject returns error dict on 500 — treated as not found."""
         mock_client = Mock()
         mock_logger = Mock()
 
-        mock_client.command.return_value = {
+        mock_client.GetObject.return_value = {
             "status_code": 500, "headers": {},
-            "body": {"errors": [{"message": "'bytes' object has no attribute 'get'"}], "resources": []}
+            "body": {"errors": [{"message": "server error"}], "resources": []}
         }
 
         exists, record = main.check_external_entity_exists(
@@ -157,7 +156,7 @@ class TestCheckExternalEntityExists(unittest.TestCase):
             "external_entity_id": "ext123",
             "external_system_id": "other_system"
         }
-        mock_client.command.return_value = json.dumps(entity_record).encode('utf-8')
+        mock_client.GetObject.return_value = json.dumps(entity_record).encode('utf-8')
 
         exists, record = main.check_external_entity_exists(
             mock_client, mock_logger, "entity123", "servicenow_incident"
@@ -175,17 +174,16 @@ class TestCreateOrUpdateExternalEntityMapping(unittest.TestCase):
         mock_logger = Mock()
 
         # Mock successful PutObject response
-        mock_client.command.return_value = {"status_code": 201}
+        mock_client.PutObject.return_value = {"status_code": 201}
 
         main.create_or_update_external_entity_mapping(
             mock_client, mock_logger,
             "entity123", "ext123", "servicenow_incident"
         )
 
-        # Verify command was called with correct args
-        mock_client.command.assert_called_once()
-        call_args = mock_client.command.call_args
-        self.assertEqual(call_args[0][0], "PutObject")
+        # Verify PutObject was called with correct args
+        mock_client.PutObject.assert_called_once()
+        call_args = mock_client.PutObject.call_args
         self.assertEqual(call_args[1]["body"]["internal_entity_id"], "entity123")
         self.assertEqual(call_args[1]["body"]["external_entity_id"], "ext123")
         self.assertEqual(call_args[1]["body"]["external_system_id"], "servicenow_incident")
@@ -195,7 +193,7 @@ class TestCreateOrUpdateExternalEntityMapping(unittest.TestCase):
         mock_logger = Mock()
 
         # Mock failed PutObject response
-        mock_client.command.return_value = {"status_code": 500}
+        mock_client.PutObject.return_value = {"status_code": 500}
 
         with self.assertRaises(main.StorageError):
             main.create_or_update_external_entity_mapping(
@@ -211,11 +209,9 @@ class TestCheckThrottlingStore(unittest.TestCase):
         mock_client = Mock()
         mock_logger = Mock()
 
-        # GetObject returns 404 dict (not found), PutObject succeeds
-        mock_client.command.side_effect = [
-            {"status_code": 404, "headers": {}, "body": {"errors": [], "resources": []}},
-            {"status_code": 201}
-        ]
+        # GetObject returns error dict (not found), PutObject succeeds
+        mock_client.GetObject.return_value = {"status_code": 404, "headers": {}, "body": {"errors": [], "resources": []}}
+        mock_client.PutObject.return_value = {"status_code": 201}
 
         is_duplicate = main.check_throttling_store(
             mock_client, mock_logger,
@@ -223,21 +219,20 @@ class TestCheckThrottlingStore(unittest.TestCase):
         )
 
         self.assertFalse(is_duplicate)
-        self.assertEqual(mock_client.command.call_count, 2)
+        mock_client.GetObject.assert_called_once()
+        mock_client.PutObject.assert_called_once()
 
     def test_first_occurrence_500_creates_record(self):
-        """GetObject returns 500 error dict — still creates new record."""
+        """GetObject returns 500 error — still creates new record."""
         mock_client = Mock()
         mock_logger = Mock()
 
         # GetObject returns 500 error dict, PutObject succeeds
-        mock_client.command.side_effect = [
-            {
-                "status_code": 500, "headers": {},
-                "body": {"errors": [{"message": "'bytes' object has no attribute 'get'"}], "resources": []}
-            },
-            {"status_code": 201}
-        ]
+        mock_client.GetObject.return_value = {
+            "status_code": 500, "headers": {},
+            "body": {"errors": [{"message": "server error"}], "resources": []}
+        }
+        mock_client.PutObject.return_value = {"status_code": 201}
 
         is_duplicate = main.check_throttling_store(
             mock_client, mock_logger,
@@ -245,7 +240,8 @@ class TestCheckThrottlingStore(unittest.TestCase):
         )
 
         self.assertFalse(is_duplicate)
-        self.assertEqual(mock_client.command.call_count, 2)
+        mock_client.GetObject.assert_called_once()
+        mock_client.PutObject.assert_called_once()
 
     def test_duplicate_occurrence(self):
         mock_client = Mock()
@@ -253,7 +249,7 @@ class TestCheckThrottlingStore(unittest.TestCase):
 
         # GetObject succeeds (record exists as bytes)
         dedup_record = {"time_bucket": main.TIME_BUCKET_FOREVER}
-        mock_client.command.return_value = json.dumps(dedup_record).encode('utf-8')
+        mock_client.GetObject.return_value = json.dumps(dedup_record).encode('utf-8')
 
         is_duplicate = main.check_throttling_store(
             mock_client, mock_logger,
@@ -262,7 +258,8 @@ class TestCheckThrottlingStore(unittest.TestCase):
 
         self.assertTrue(is_duplicate)
         # Should only call GetObject, not PutObject
-        self.assertEqual(mock_client.command.call_count, 1)
+        mock_client.GetObject.assert_called_once()
+        mock_client.PutObject.assert_not_called()
 
     def test_invalid_time_bucket(self):
         mock_client = Mock()
@@ -351,11 +348,8 @@ class TestCheckIfExtEntityExistsHandler(unittest.TestCase):
         mock_client = Mock()
         mock_create_clients.return_value = (Mock(), mock_client)
 
-        # GetObject returns error dict (500 response)
-        mock_client.command.return_value = {
-            "status_code": 500, "headers": {},
-            "body": {"errors": [{"message": "'bytes' object has no attribute 'get'"}], "resources": []}
-        }
+        # GetObject returns error dict (404)
+        mock_client.GetObject.return_value = {"status_code": 404, "headers": {}, "body": {"errors": [], "resources": []}}
 
         mock_request = Mock()
         mock_request.trace_id = "trace-123"
@@ -536,11 +530,8 @@ class TestCreateIncidentHandlers(unittest.TestCase):
         mock_client = Mock()
         mock_create_clients.return_value = (mock_api_integrations, mock_client)
 
-        # GetObject returns 404 on entity check, PutObject succeeds for mapping
-        mock_client.command.side_effect = [
-            {"status_code": 404, "headers": {}, "body": {"errors": [], "resources": []}},  # check_external_entity_exists
-            {"status_code": 201}  # create_or_update → PutObject
-        ]
+        # GetObject returns 404 on entity check
+        mock_client.GetObject.return_value = {"status_code": 404, "body": {}}
 
         # Mock successful ServiceNow response
         mock_api_integrations.execute_command.return_value = {
@@ -695,10 +686,8 @@ class TestThrottleHandler(unittest.TestCase):
         mock_create_clients.return_value = (Mock(), mock_client)
 
         # GetObject returns 404, PutObject succeeds
-        mock_client.command.side_effect = [
-            {"status_code": 404, "headers": {}, "body": {"errors": [], "resources": []}},  # GetObject → not found
-            {"status_code": 201}  # PutObject → created
-        ]
+        mock_client.GetObject.return_value = {"status_code": 404, "body": {}}
+        mock_client.PutObject.return_value = {"status_code": 201}
 
         mock_request = Mock()
         mock_request.trace_id = "trace-123"
@@ -714,7 +703,8 @@ class TestThrottleHandler(unittest.TestCase):
         self.assertEqual(response.code, HTTPStatus.OK)
         self.assertTrue(response.body["allowed"])
         # Should have called GetObject then PutObject
-        self.assertEqual(mock_client.command.call_count, 2)
+        mock_client.GetObject.assert_called_once()
+        mock_client.PutObject.assert_called_once()
 
     @patch('main.create_falcon_clients')
     @patch('main.check_throttling_store')


### PR DESCRIPTION
Replaces APIHarnessV2 (Uber class) with CustomStorage (service class) for collection CRUD operations in the ITSM helper function.

The Falcon Foundry Functions Editor parses `from falconpy import CustomStorage` to auto-detect required OAuth scopes (`custom-storage:read`, `custom-storage:write`). It cannot parse the Uber class `.command()` pattern, which means apps using APIHarnessV2 require manual scope configuration.

Changes in **main.py**:
- `APIHarnessV2().command("GetObject", ...)` → `CustomStorage().GetObject(...)`
- `APIHarnessV2().command("PutObject", ...)` → `CustomStorage().PutObject(...)`
- Simplified `GetObject` response handling: check `status_code` instead of decoding bytes

Changes in **test_main.py**:
- Updated mocks from bytes responses to dict responses with `status_code`/`body`
- `mock_client.command` → `mock_client.GetObject` / `mock_client.PutObject`

Related PRs with the same migration:
- CrowdStrike/foundry-sample-functions-python#118
- CrowdStrike/foundry-sample-anomali-threatstream#51
- CrowdStrike/foundry-sample-collections-toolkit#120
- CrowdStrike/foundry-sample-category-blocking#100