### PR TITLE
Fix auth type dropdown selection in app install flow

### DIFF
--- a/e2e/src/pages/AppCatalogPage.ts
+++ b/e2e/src/pages/AppCatalogPage.ts
@@ -4,7 +4,6 @@
 
 import { Page } from '@playwright/test';
 import { BasePage } from './BasePage';
-import { RetryHandler } from '../utils/SmartWaiter';
 import { config } from '../config/TestConfig';
 
 export class AppCatalogPage extends BasePage {
@@ -159,16 +158,22 @@ export class AppCatalogPage extends BasePage {
     this.logger.debug('Filled Configuration name');
 
     // Step 2: Select Basic Authentication from dropdown
-    this.logger.debug('Clicking authentication type dropdown');
+    // falcon-select only responds to keyboard navigation, not .click() on options
+    this.logger.debug('Selecting Basic Authentication via keyboard');
     await authTypeButton.click();
-
-    const basicAuthOption = this.page.getByRole('option', { name: 'Basic Authentication' });
-    await this.waiter.waitForVisible(basicAuthOption, { description: 'Basic Authentication option' });
-    await basicAuthOption.click();
+    const listbox = this.page.getByRole('listbox', { name: /Authentication Type/i });
+    await listbox.waitFor({ state: 'visible', timeout: 5000 });
+    const options = listbox.getByRole('option');
+    const count = await options.count();
+    for (let i = 0; i < count; i++) await listbox.press('ArrowUp');
+    for (let i = 0; i < count; i++) {
+      if ((await options.nth(i).textContent())?.trim() === 'Basic Authentication') break;
+      await listbox.press('ArrowDown');
+    }
+    await listbox.press('Enter');
     this.logger.debug('Selected Basic Authentication');
 
-    // Wait for form to update after selecting auth type
-    await this.waiter.delay(1000);
+    await this.page.waitForLoadState('networkidle');
 
     // Step 3: Fill ServiceNow Instance URL (use env var or error)
     const serviceNowUrl = process.env.SERVICENOW_INSTANCE_URL;


### PR DESCRIPTION
The Falcon UI's `falcon-select` Ember component ignores `.click()` on `<option>` elements. The auth type dropdown now defaults to OAuth 2.0 instead of Basic Authentication, so selecting Basic Auth via `.click()` silently does nothing — leaving OAuth 2.0 selected and causing the install to fail (wrong credential fields shown).

The fix opens the dropdown and uses keyboard navigation (`ArrowUp` + `Enter` on the listbox) to select Basic Authentication, matching how the Ember component actually processes selection changes. Also removes an unused `RetryHandler` import.

Verified locally — all 4 E2E tests pass (authenticate, install with ServiceNow config, verify workflow actions, uninstall).