### PR TITLE
Add pip ecosystem to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,13 @@ updates:
       day: "monday"
       time: "14:00"
       timezone: "UTC"
+  - package-ecosystem: "pip"
+    directory: "/functions/itsmhelper/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "14:00"
+      timezone: "UTC"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
The itsmhelper function has a requirements.txt with Python dependencies (crowdstrike-foundry-function, crowdstrike-falconpy) that were not being monitored by dependabot. This adds pip monitoring alongside the existing gomod and github-actions ecosystems to ensure Python dependencies receive automated update PRs.