### PR TITLE
Pin crowdstrike-falconpy and add pip to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,13 @@ updates:
       day: "monday"
       time: "14:00"
       timezone: "UTC"
+  - package-ecosystem: "pip"
+    directory: "/functions/itsmhelper/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "14:00"
+      timezone: "UTC"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/functions/itsmhelper/requirements.txt
+++ b/functions/itsmhelper/requirements.txt
@@ -1,2 +1,2 @@
 crowdstrike-foundry-function==1.1.4
-crowdstrike-falconpy
+crowdstrike-falconpy==1.6.2


### PR DESCRIPTION
Pins crowdstrike-falconpy to 1.6.2 in requirements.txt to prevent supply chain risks from unpinned packages. Also adds the pip ecosystem to the dependabot configuration so that Python dependencies in the itsmhelper function receive automated update PRs alongside the existing gomod monitoring.