### PR TITLE
Add pip ecosystem to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,14 @@ updates:
       day: "monday"
       time: "14:00"
       timezone: "UTC"
+  - package-ecosystem: "pip"
+    directories:
+      - "/functions/itsmhelper/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "14:00"
+      timezone: "UTC"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
The repo has both Go and Python function implementations but dependabot was only configured for gomod and github-actions, leaving the Python requirements.txt unmonitored for security updates.