### PR TITLE
Add OAuth 2.0 JWT Bearer authentication support for ServiceNow

### DIFF
--- a/USERDOCS.md
+++ b/USERDOCS.md
@@ -458,7 +458,7 @@ This configuration will allow users to select values from the custom table when 
 
 ### OAuth 2.0 Client Credentials configuration
 
-This application support both Basic Auth and OAuth 2.0 Client Credentials grant.
+This application supports Basic Auth, OAuth 2.0 Client Credentials, and OAuth 2.0 JWT Bearer grant.
 
 #### Prerequisites
 - **Set system property**: `glide.oauth.inbound.client.credential.grant_type.enabled` = `true`. This property enables "Client Credentials" grant type in ServiceNow ([reference](https://support.servicenow.com/kb?id=kb_article_view&sysparm_article=KB1645212)).
@@ -469,3 +469,69 @@ This application support both Basic Auth and OAuth 2.0 Client Credentials grant.
 3. Complete required fields (Redirect URL and Login URL not needed)
 4. Add **OAuth Application User** field to the form
 5. **Assign a service account** to the OAuth Application User field
+
+### OAuth 2.0 JWT Bearer configuration
+
+The JWT Bearer grant enables authentication using a signed JWT assertion instead of user credentials. This is suited for machine-to-machine integrations where interactive login is not possible.
+
+For full details, see the [ServiceNow documentation](https://www.servicenow.com/docs/r/zurich/platform-security/authentication/create-jwt-endpoint.html).
+
+#### Prerequisites
+- ServiceNow instance with OAuth enabled (admin role required)
+- An RSA key pair (supported algorithms: RS256, RS384, RS512, ES256, ES384, ES512)
+
+#### Generating an RSA Key Pair
+```bash
+# Generate private key
+openssl genrsa -out private_key.pem 2048
+
+# Extract public key
+openssl rsa -in private_key.pem -pubout -out public_key.pem
+```
+
+#### Configuring ServiceNow
+
+1. **Upload the public key** to the `sys_certificate` table in your ServiceNow instance.
+
+2. **Create the OAuth JWT endpoint:**
+   1. Navigate to **System OAuth → Application Registry**
+   2. Select **Create an OAuth JWT API endpoint for external clients**
+   3. Complete the form:
+      - **Name**: A descriptive name for the application
+      - **Client ID**: Auto-generated unique ID (used as the `aud` claim in the JWT)
+      - **Client Secret**: Auto-generated or custom value (can be omitted for public clients)
+      - **User Field**: Field in the User (`sys_user`) table used to match the `sub` claim (e.g., Email)
+      - **Enable JTI Verification**: Requires a unique token for every exchange (recommended)
+      - **Access Token Lifespan**: Duration in seconds that the issued access token is valid
+   4. Save the form.
+
+3. **Add a JWT Verifier Map** (related list on the OAuth JWT record):
+   - **Name**: A descriptive name
+   - **Kid**: Key ID that matches the `kid` header in the JWT
+   - **Sys certificate**: Select the certificate uploaded in step 1
+
+4. **Add Claim Validations** (optional, via the OAuth JWT Claim Validations related list):
+   - Add any custom claims your JWT includes. The standard claims (`iss`, `aud`, `sub`, `exp`) do not need entries here.
+   - If `iss` differs from `aud` (Client ID), add `iss` to the claim validations.
+
+#### JWT Claims
+
+The JWT must contain the following claims:
+| Claim | Description |
+|-------|-------------|
+| `aud` | Must match the **Client ID** of the ServiceNow OAuth application |
+| `sub` | User identifier (e.g., email) matching the configured **User Field** |
+| `iss` | Issuer identifier; recommended to match the Client ID |
+| `exp` | Token expiration time |
+| `kid` | (header) Key ID matching the JWT Verifier Map entry |
+
+#### Configuring the Connection in Falcon
+
+When creating the ServiceNow connection, select **OAuth 2.0 JWT Bearer** and provide:
+- **Client ID**: The Client ID from the ServiceNow OAuth JWT application
+- **Client Secret**: The Client Secret (can be omitted if Public Client is enabled in ServiceNow)
+- **Private Key PEM file**: Upload your `private_key.pem` file
+- **Key ID (kid claim)**: Must match the **Kid** field in the ServiceNow JWT Verifier Map
+- **Subject (sub claim)**: The user identifier matching the ServiceNow User Field (e.g., `admin@example.com`)
+- **Audience (aud claim)**: Must match the ServiceNow OAuth application's **Client ID**
+- **Issuer (iss claim)**: Must match the issuer configured in ServiceNow (typically the Client ID)

--- a/USERDOCS.md
+++ b/USERDOCS.md
@@ -529,7 +529,7 @@ The JWT must contain the following claims:
 
 When creating the ServiceNow connection, select **OAuth 2.0 JWT Bearer** and provide:
 - **Client ID**: The Client ID from the ServiceNow OAuth JWT application
-- **Client Secret**: The Client Secret (can be omitted if Public Client is enabled in ServiceNow)
+- **Client Secret**: The Client Secret from the ServiceNow OAuth JWT application
 - **Private Key PEM file**: Upload your `private_key.pem` file
 - **Key ID (kid claim)**: Must match the **Kid** field in the ServiceNow JWT Verifier Map
 - **Subject (sub claim)**: The user identifier matching the ServiceNow User Field (e.g., `admin@example.com`)

--- a/USERDOCS.md
+++ b/USERDOCS.md
@@ -510,10 +510,6 @@ openssl rsa -in private_key.pem -pubout -out public_key.pem
    - **Kid**: Key ID that matches the `kid` header in the JWT
    - **Sys certificate**: Select the certificate uploaded in step 1
 
-4. **Add Claim Validations** (optional, via the OAuth JWT Claim Validations related list):
-   - Add any custom claims your JWT includes. The standard claims (`iss`, `aud`, `sub`, `exp`) do not need entries here.
-   - If `iss` differs from `aud` (Client ID), add `iss` to the claim validations.
-
 #### JWT Claims
 
 The JWT must contain the following claims:

--- a/api-integrations/servicenow.json
+++ b/api-integrations/servicenow.json
@@ -104,6 +104,132 @@
                   "oauth2_1"
                 ],
                 "type": "object"
+              },
+              {
+                "properties": {
+                  "oauth2_2": {
+                    "properties": {
+                      "client_id": {
+                        "minLength": 1,
+                        "title": "Client ID",
+                        "type": "string"
+                      },
+                      "client_secret": {
+                        "format": "password",
+                        "minLength": 1,
+                        "title": "Client Secret",
+                        "type": "string"
+                      },
+                      "jwt_bearer_config": {
+                        "properties": {
+                          "private_key": {
+                            "type": "object",
+                            "title": "Private Key PEM file",
+                            "properties": {
+                              "contents": {
+                                "type": "string",
+                                "format": "password"
+                              },
+                              "file_name": {
+                                "type": "string"
+                              }
+                            },
+                            "x-cs-ui": {
+                              "component": "workflow-extension-file-upload",
+                              "accept": [".pem"],
+                              "encoding": "base64"
+                            }
+                          },
+                          "private_key_id": {
+                            "title": "Key ID (kid claim)",
+                            "type": "string"
+                          },
+                          "algorithm": {
+                            "default": "RS256",
+                            "enum": [
+                              "RS256",
+                              "RS384",
+                              "RS512"
+                            ],
+                            "type": "string"
+                          },
+                          "subject": {
+                            "title": "Subject (sub claim)",
+                            "type": "string"
+                          },
+                          "audience": {
+                            "title": "Audience (aud claim)",
+                            "type": "string"
+                          },
+                          "issuer": {
+                            "title": "Issuer (iss claim)",
+                            "type": "string"
+                          },
+                          "additional_claims": {
+                            "properties": {
+                              "jti": {
+                                "default": "{jti}",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "required": [
+                          "private_key",
+                          "private_key_id",
+                          "subject",
+                          "audience",
+                          "issuer"
+                        ],
+                        "type": "object"
+                      },
+                      "request": {
+                        "properties": {
+                          "x-www-form-urlencoded": {
+                            "properties": {
+                              "grant_type": {
+                                "default": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                                "type": "string"
+                              },
+                              "assertion": {
+                                "default": "{jwt_assertion}",
+                                "type": "string"
+                              },
+                              "client_id": {
+                                "default": "{client_id}",
+                                "type": "string"
+                              },
+                              "client_secret": {
+                                "default": "{client_secret}",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "client_id",
+                      "jwt_bearer_config"
+                    ],
+                    "type": "object"
+                  },
+                  "type": {
+                    "default": "oauth2_2",
+                    "enum": [
+                      "oauth2_2"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "oauth2_2"
+                ],
+                "type": "object"
               }
             ],
             "type": "object"
@@ -133,6 +259,17 @@
         "flows": {
           "clientCredentials": {
             "tokenUrl": "/oauth_token.do"
+          }
+        },
+        "type": "oauth2"
+      },
+      "oauth2_jwt_bearer": {
+        "bearerFormat": "Bearer",
+        "flows": {
+          "x-cs-custom-flow": {
+            "jwtBearer": {
+              "tokenUrl": "https://{base_url}/oauth_token.do"
+            }
           }
         },
         "type": "oauth2"
@@ -2310,7 +2447,8 @@
   },
   "security": [
     { "http_basic": [] },
-    { "oauth2": [] }
+    { "oauth2": [] },
+    { "oauth2_jwt_bearer": [] }
   ],
   "servers": [
     {
@@ -2365,6 +2503,10 @@
                           {
                             "id": "oauth2_1",
                             "label": "OAuth 2.0 Client Credentials"
+                          },
+                          {
+                            "id": "oauth2_2",
+                            "label": "OAuth 2.0 JWT Bearer"
                           }
                         ],
                         "payloadVersion": "v1",
@@ -2446,6 +2588,172 @@
                       [
                         10,
                         1
+                      ]
+                    ],
+                    "version": "0.3.1"
+                  }
+                },
+                "oauth2_2": {
+                  "mobiledoc": {
+                    "cards": [
+                      [
+                        "form/input/mobiledoc",
+                        {
+                          "label": "Client ID",
+                          "name": "auth.oauth2_2.client_id",
+                          "payloadVersion": "v1"
+                        }
+                      ],
+                      [
+                        "form/input/mobiledoc",
+                        {
+                          "label": "Client Secret",
+                          "name": "auth.oauth2_2.client_secret",
+                          "payloadVersion": "v1",
+                          "type": "password"
+                        }
+                      ],
+                      [
+                        "workflow-extensions/file-upload/mobiledoc",
+                        {
+                          "accept": ".pem",
+                          "encoding": "base64",
+                          "label": "Private Key PEM file",
+                          "name": "auth.oauth2_2.jwt_bearer_config.private_key",
+                          "payloadVersion": "v1"
+                        }
+                      ],
+                      [
+                        "form/input/mobiledoc",
+                        {
+                          "label": "Key ID (kid claim)",
+                          "name": "auth.oauth2_2.jwt_bearer_config.private_key_id",
+                          "payloadVersion": "v1"
+                        }
+                      ],
+                      [
+                        "form/input/mobiledoc",
+                        {
+                          "label": "Subject (sub claim)",
+                          "name": "auth.oauth2_2.jwt_bearer_config.subject",
+                          "payloadVersion": "v1"
+                        }
+                      ],
+                      [
+                        "form/input/mobiledoc",
+                        {
+                          "label": "Audience (aud claim)",
+                          "name": "auth.oauth2_2.jwt_bearer_config.audience",
+                          "payloadVersion": "v1"
+                        }
+                      ],
+                      [
+                        "form/input/mobiledoc",
+                        {
+                          "label": "Issuer (iss claim)",
+                          "name": "auth.oauth2_2.jwt_bearer_config.issuer",
+                          "payloadVersion": "v1"
+                        }
+                      ],
+                      [
+                        "form/input/mobiledoc",
+                        {
+                          "label": "JTI",
+                          "name": "auth.oauth2_2.jwt_bearer_config.additional_claims.jti",
+                          "payloadVersion": "v1",
+                          "type": "hidden",
+                          "value": "{jti}"
+                        }
+                      ],
+                      [
+                        "form/input/mobiledoc",
+                        {
+                          "label": "Grant Type",
+                          "name": "auth.oauth2_2.request.x-www-form-urlencoded.grant_type",
+                          "payloadVersion": "v1",
+                          "type": "hidden",
+                          "value": "urn:ietf:params:oauth:grant-type:jwt-bearer"
+                        }
+                      ],
+                      [
+                        "form/input/mobiledoc",
+                        {
+                          "label": "Assertion",
+                          "name": "auth.oauth2_2.request.x-www-form-urlencoded.assertion",
+                          "payloadVersion": "v1",
+                          "type": "hidden",
+                          "value": "{jwt_assertion}"
+                        }
+                      ],
+                      [
+                        "form/input/mobiledoc",
+                        {
+                          "label": "Client ID",
+                          "name": "auth.oauth2_2.request.x-www-form-urlencoded.client_id",
+                          "payloadVersion": "v1",
+                          "type": "hidden",
+                          "value": "{client_id}"
+                        }
+                      ],
+                      [
+                        "form/input/mobiledoc",
+                        {
+                          "label": "Client Secret",
+                          "name": "auth.oauth2_2.request.x-www-form-urlencoded.client_secret",
+                          "payloadVersion": "v1",
+                          "type": "hidden",
+                          "value": "{client_secret}"
+                        }
+                      ]
+                    ],
+                    "sections": [
+                      [
+                        10,
+                        0
+                      ],
+                      [
+                        10,
+                        1
+                      ],
+                      [
+                        10,
+                        2
+                      ],
+                      [
+                        10,
+                        3
+                      ],
+                      [
+                        10,
+                        4
+                      ],
+                      [
+                        10,
+                        5
+                      ],
+                      [
+                        10,
+                        6
+                      ],
+                      [
+                        10,
+                        7
+                      ],
+                      [
+                        10,
+                        8
+                      ],
+                      [
+                        10,
+                        9
+                      ],
+                      [
+                        10,
+                        10
+                      ],
+                      [
+                        10,
+                        11
                       ]
                     ],
                     "version": "0.3.1"

--- a/app_docs/README.md
+++ b/app_docs/README.md
@@ -13,6 +13,7 @@ The ServiceNow ITSM and SIR App is a Foundry application that facilitates integr
 ## Authentication Support
 - Basic Authentication
 - OAuth 2.0 Client Credentials grant
+- OAuth 2.0 JWT Bearer grant
 
 ## Documentation
 - The source code for this app can be found on GitHub: [https://github.com/CrowdStrike/foundry-sample-servicenow-itsm](https://github.com/CrowdStrike/foundry-sample-servicenow-itsm)


### PR DESCRIPTION
## Summary
- Add OAuth 2.0 JWT Bearer grant type as a third authentication option alongside Basic Auth and Client Credentials
- Configure JWT signing with RSA key upload, configurable claims (sub, aud, iss, kid), and automatic assertion generation
- Add user-facing documentation covering ServiceNow setup, key generation, and connection configuration

## Test plan
- [x] Tested end-to-end against a ServiceNow instance