### PR TITLE
Add "Update Incident" / "Update SIR Incident" actions with custom field handling

### DIFF
--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -94,7 +94,56 @@ This action creates a Security Incident Response (SIR) incident in ServiceNow. I
 **Response**:
 - Same structure as Create Incident response
 
-### 5. Throttle
+### 5. Update Incident
+**Name**: `ITSM Helper - Update Incident`  
+**Handler**: `HandleUpdateIncident`  
+**API Path**: `/update_incident`  
+
+**Description**:  
+This action updates an existing standard incident in ServiceNow, identified by its `sys_id`. Like the create actions, it flattens the `custom_fields` JSON string into top-level fields before sending to ServiceNow, allowing arbitrary custom fields to be updated without editing the API integration definition. All field updates are optional — only the fields provided are sent.
+
+**Schema Files**:
+- Request Schema: [update_incident_req_schema.json](functions/itsmhelper/schemas/update_incident_req_schema.json)
+- Response Schema: [update_incident_resp_schema.json](functions/itsmhelper/schemas/update_incident_resp_schema.json)
+
+**Request Parameters**:
+- `config_id` (string, required): Configuration ID for the ServiceNow integration
+- `sys_id` (string, required): The unique identifier (sys_id) of the ServiceNow incident to update (passed as a path parameter)
+- `short_description` (string, optional): Brief description of the incident
+- `assignment_group` (string, optional): Group to assign the incident to
+- `category` (string, optional): Incident category
+- `description` (string, optional): Detailed description
+- `impact` (string, optional): Impact level
+- `severity` (string, optional): Severity level
+- `state` (string, optional): Incident state
+- `urgency` (string, optional): Urgency level
+- `work_notes` (string, optional): Additional notes
+- `custom_fields` (string, optional): JSON string containing custom ServiceNow fields as key-value pairs (e.g., `{"u_custom_field1": "value1", "u_affected_systems": 3}`)
+
+**Response**:
+- `ticket_id` (string): The ServiceNow ticket ID (sys_id)
+- `ticket_type` (string): The type of ticket updated (`incident`)
+- `number` (string): The ServiceNow ticket number
+
+### 6. Update SIR Incident
+**Name**: `ITSM Helper - Update SIR Incident`  
+**Handler**: `HandleUpdateSIRIncident`  
+**API Path**: `/update_sir_incident`  
+
+**Description**:  
+This action updates an existing Security Incident Response (SIR) incident in ServiceNow, identified by its `sys_id`. It functions similarly to the Update Incident handler but targets the `sn_si_incident` table and exposes SIR-specific category, severity, and state options.
+
+**Schema Files**:
+- Request Schema: [update_sir_incident_req_schema.json](functions/itsmhelper/schemas/update_sir_incident_req_schema.json)
+- Response Schema: [update_sir_incident_resp_schema.json](functions/itsmhelper/schemas/update_sir_incident_resp_schema.json)
+
+**Request Parameters**:
+- Same as Update Incident, but with different category and severity options specific to SIR incidents
+
+**Response**:
+- Same structure as Update Incident response (`ticket_type` is `sn_si_incident`)
+
+### 7. Throttle
 **Name**: `ITSM Helper - Throttle`  
 **Handler**: `HandleThrottle`  
 **API Path**: `/throttle`  
@@ -119,9 +168,11 @@ This action provides throttling functionality to control the flow of updates in 
 
 All actions are part of a single function called `itsm_helper`. This function is exposed to Workflow through the integrations listed above.
 
-The ServiceNow ITSM and SIR App uses the ServiceNow API integration (Name: `servicenow-foundry`, defined in [api-integrations/servicenow.json](api-integrations/servicenow.json)) to communicate with ServiceNow. It supports two main operations:
+The ServiceNow ITSM and SIR App uses the ServiceNow API integration (Name: `servicenow-foundry`, defined in [api-integrations/servicenow.json](api-integrations/servicenow.json)) to communicate with ServiceNow. It supports the following main operations:
 - `create_incident`: Creates a standard incident in ServiceNow
 - `create_sn_si_incident`: Creates a Security Incident Response (SIR) incident in ServiceNow
+- `update_incident`: Updates a standard incident in ServiceNow
+- `update_sn_si_incident`: Updates a Security Incident Response (SIR) incident in ServiceNow
 
 The app also uses two custom collections for storage:
 1. `tracked_entities`: Stores mappings between CrowdStrike entities and ServiceNow tickets
@@ -135,12 +186,12 @@ The handlers in this project connect to ServiceNow through the OpenAPI Specifica
 
 2. The handlers reference this integration by name when communicating with ServiceNow through the Falcon API Integrations client.
 
-3. When creating incidents, the handlers specify which operation to execute:
-   - For standard incidents: `create_incident`
-   - For SIR incidents: `create_sn_si_incident`
+3. When creating or updating incidents, the handlers specify which operation to execute:
+   - For standard incidents: `create_incident` / `update_incident`
+   - For SIR incidents: `create_sn_si_incident` / `update_sn_si_incident`
 
 4. These operations are defined in the OAS file and map to specific ServiceNow API endpoints:
-   - Standard incidents: `/api/now/table/incident` (POST)
-   - SIR incidents: `/api/now/table/sn_si_incident` (POST)
+   - Standard incidents: `/api/now/table/incident` (POST), `/api/now/table/incident/{sys_id}` (PATCH)
+   - SIR incidents: `/api/now/table/sn_si_incident` (POST), `/api/now/table/sn_si_incident/{sys_id}` (PATCH)
 
 This integration allows the app to create and manage tickets in ServiceNow while maintaining mappings between CrowdStrike entities and ServiceNow tickets in the custom storage.

--- a/USERDOCS.md
+++ b/USERDOCS.md
@@ -90,6 +90,7 @@ To implement alert synchronization, you'll need to create workflows that use the
 
 - **Check If External Entity Exists**: Checks if a ticket already exists for a given CrowdStrike entity
 - **Create Incident** or **Create SIR Incident**: Creates a new ticket in ServiceNow
+- **Update Incident** or **Update SIR Incident**: Updates an existing ticket in ServiceNow (identified by its `sys_id`)
 
 #### Alert Creation - Workflow
 
@@ -109,12 +110,12 @@ You can customize these fields in your workflow to ensure that the created ticke
 
 #### Alert Updates - Separate Workflow
 
-For existing alerts, a completely separate workflow from alert creation is used. This workflow is triggered specifically by "Audit Event > Alert" events and uses the ServiceNow API integration directly to update the ticket with new information. This can be done by:
+For existing alerts, a completely separate workflow from alert creation is used. This workflow is triggered specifically by "Audit Event > Alert" events and uses the **Update Incident** or **Update SIR Incident** ITSM Helper action to update the ticket with new information. Like the create actions, these update actions support a `custom_fields` JSON string for setting arbitrary ServiceNow fields without editing the API integration. This can be done by:
 
 1. Create a workflow in Falcon Fusion that triggers on Audit Event related to tracked entities (e.g., Alerts)
-2. Using the "Check If External Entity Exists" action to get the ticket ID related to this entity (e.g., Alert)
+2. Using the "Check If External Entity Exists" action to get the ticket ID (`sys_id`) related to this entity (e.g., Alert)
    <br><img alt="Alert update trigger workflow view" src="images/userdocs/oneway_alert_sync_update_trigger_view.png" width="800"/>
-3. Using the ServiceNow API integration to update the ticket with the new information
+3. Using the "Update Incident" (or "Update SIR Incident") action with the retrieved `sys_id` and `config_id` to update the ticket with the new information
    <br><img alt="ServiceNow API action for updating ticket" src="images/userdocs/oneway_alert_sync_update_close_action.png" width="800"/><br>
 4. The complete alert update workflow overview:
    <br><img alt="Complete alert update workflow overview" src="images/userdocs/oneway_alert_sync_update_overview.png" width="1200"/><br>
@@ -307,7 +308,7 @@ When implemented correctly, selecting a value in the parent field will automatic
 
 ServiceNow often includes custom fields (prefixed with "u_" or "x_") that are specific to an organization's implementation. The ServiceNow ITSM and SIR app provides two approaches to incorporate these custom fields:
 
-1. **Using the "Custom Fields JSON (advanced)" parameter**: Pass any custom fields as a JSON string without modifying the app
+1. **Using the "Custom Fields JSON (advanced)" parameter**: Pass any custom fields as a JSON string without modifying the app. This parameter is supported by the Create Incident, Create SIR Incident, Update Incident, and Update SIR Incident actions.
    ```json
    {
      "u_custom_field1": "value1",
@@ -335,6 +336,7 @@ Choose the first approach for flexibility and simplicity, especially for dynamic
    - Add the custom field to the appropriate schema file:
      - `functions/itsmhelper/schemas/create_incident_req_schema.json` for regular incidents
      - `functions/itsmhelper/schemas/create_sir_incident_req_schema.json` for SIR incidents
+     - `functions/itsmhelper/schemas/update_incident_req_schema.json` / `update_sir_incident_req_schema.json` if the field should also be available on the update actions
    - Include the field in the `x-cs-order` array to control its position in the UI
 
 4. **Deploy the Updated Integration**:

--- a/api-integrations/servicenow.json
+++ b/api-integrations/servicenow.json
@@ -469,18 +469,6 @@
               }
             }
           }
-        },
-        "x-cs-operation-config": {
-          "timeout_seconds": 30,
-          "workflow": {
-            "description": "Update Incident - Foundry",
-            "expose_to_workflow": true,
-            "name": "Update ServiceNow Incident - Foundry",
-            "system": false,
-            "tags": [
-              "ServiceNow Foundry"
-            ]
-          }
         }
       }
     },
@@ -923,18 +911,6 @@
                 }
               }
             }
-          }
-        },
-        "x-cs-operation-config": {
-          "timeout_seconds": 30,
-          "workflow": {
-            "description": "Update SIR Incident - Foundry",
-            "expose_to_workflow": true,
-            "name": "Update ServiceNow SIR Incident - Foundry",
-            "system": false,
-            "tags": [
-              "ServiceNow Foundry"
-            ]
           }
         }
       }

--- a/functions/itsmhelper/internal/handler/handlers.go
+++ b/functions/itsmhelper/internal/handler/handlers.go
@@ -26,6 +26,9 @@ var (
 
 	pluginOpIDServiceNowCreateIncident    = "create_incident"
 	pluginOpIDServiceNowCreateSIRIncident = "create_sn_si_incident"
+
+	pluginOpIDServiceNowUpdateIncident    = "update_incident"
+	pluginOpIDServiceNowUpdateSIRIncident = "update_sn_si_incident"
 )
 
 type CheckIfExtExistsReq struct {
@@ -61,6 +64,30 @@ type CreateIncidentResponse struct {
 	Exists     bool   `json:"exists"`
 	TicketID   string `json:"ticket_id"`
 	TicketType string `json:"ticket_type"`
+}
+
+// UpdateIncidentRequest represents the request body for updating an incident
+type UpdateIncidentRequest struct {
+	ConfigID string `json:"config_id"`
+	SysID    string `json:"sys_id"`
+
+	AssignmentGroup  string `json:"assignment_group"`
+	Category         string `json:"category"`
+	Description      string `json:"description"`
+	Impact           string `json:"impact"`
+	Severity         string `json:"severity"`
+	ShortDescription string `json:"short_description"`
+	State            string `json:"state"`
+	Urgency          string `json:"urgency"`
+	WorkNotes        string `json:"work_notes"`
+	CustomFields     string `json:"custom_fields"`
+}
+
+// UpdateIncidentResponse represents the response body for updating an incident
+type UpdateIncidentResponse struct {
+	TicketID   string `json:"ticket_id"`
+	TicketType string `json:"ticket_type"`
+	Number     string `json:"number"`
 }
 
 // ThrottleFunctionRequest represents the schema for deduplication requests
@@ -162,6 +189,51 @@ func buildRequestPayload(body CreateIncidentRequest) map[string]interface{} {
 	}
 
 	// Add optional fields if they are provided
+	if body.AssignmentGroup != "" {
+		requestPayload["assignment_group"] = body.AssignmentGroup
+	}
+	if body.Category != "" {
+		requestPayload["category"] = body.Category
+	}
+	if body.Description != "" {
+		requestPayload["description"] = body.Description
+	}
+	if body.Impact != "" {
+		requestPayload["impact"] = body.Impact
+	}
+	if body.Severity != "" {
+		requestPayload["severity"] = body.Severity
+	}
+	if body.State != "" {
+		requestPayload["state"] = body.State
+	}
+	if body.Urgency != "" {
+		requestPayload["urgency"] = body.Urgency
+	}
+	if body.WorkNotes != "" {
+		requestPayload["work_notes"] = body.WorkNotes
+	}
+
+	if body.CustomFields != "" {
+		var customFields map[string]interface{}
+		if err := json.Unmarshal([]byte(body.CustomFields), &customFields); err == nil {
+			for key, value := range customFields {
+				requestPayload[key] = value
+			}
+		}
+	}
+
+	return requestPayload
+}
+
+// buildUpdateRequestPayload creates the request payload from the update incident request.
+// Unlike buildRequestPayload, all fields are optional - only non-empty fields are included.
+func buildUpdateRequestPayload(body UpdateIncidentRequest) map[string]interface{} {
+	requestPayload := map[string]interface{}{}
+
+	if body.ShortDescription != "" {
+		requestPayload["short_description"] = body.ShortDescription
+	}
 	if body.AssignmentGroup != "" {
 		requestPayload["assignment_group"] = body.AssignmentGroup
 	}
@@ -355,6 +427,123 @@ func (h *Handler) HandleCreateIncident(ctx context.Context, r fdk.RequestOf[Crea
 // HandleCreateSIRIncident handles the /create_sir_incident endpoint
 func (h *Handler) HandleCreateSIRIncident(ctx context.Context, r fdk.RequestOf[CreateIncidentRequest], wrkCtx fdk.WorkflowCtx) fdk.Response {
 	return h.createIncident(ctx, r, wrkCtx, pluginOpIDServiceNowCreateSIRIncident, "sn_si_incident", ExternalSystemIDServiceNowSIRIncident)
+}
+
+// updateIncident handles the common logic for updating both regular and SIR incidents
+func (h *Handler) updateIncident(
+	ctx context.Context,
+	r fdk.RequestOf[UpdateIncidentRequest],
+	wrkCtx fdk.WorkflowCtx,
+	operationID string,
+	ticketType string,
+) fdk.Response {
+	h.logger.Info("Updating incident", "type", ticketType, "trace_id", r.TraceID, "wrk_ctx", wrkCtx)
+	accessToken := r.AccessToken
+
+	falconClient, cloud, err := h.falconClientFunc(accessToken, h.logger)
+	if err != nil {
+		errMsg := fmt.Sprintf("error creating Falcon client: %v", err)
+		return fdk.ErrResp(fdk.APIError{Code: http.StatusInternalServerError, Message: errMsg})
+	}
+	_ = cloud
+
+	// Build the update payload, flattening any custom fields into the root
+	requestPayload := buildUpdateRequestPayload(r.Body)
+
+	configID := r.Body.ConfigID
+	execCmdParams := &api_integrations.ExecuteCommandParams{
+		Body: &models.DomainExecuteCommandRequestV1{Resources: []*models.DomainExecuteCommandV1{
+			{
+				DefinitionID: &pluginDefIDServiceNow,
+				OperationID:  &operationID,
+				ConfigID:     &configID,
+				Request: &models.DomainRequest{
+					JSON: requestPayload,
+					Params: &models.DomainParams{
+						Path: map[string]interface{}{"sys_id": r.Body.SysID},
+					},
+				},
+			},
+		}},
+		Context: ctx,
+	}
+
+	execResp, err := falconClient.APIIntegrations.ExecuteCommand(execCmdParams)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to execute command: %v", err)
+		return fdk.ErrResp(fdk.APIError{Code: http.StatusInternalServerError, Message: errMsg})
+	}
+
+	if execResp == nil {
+		return fdk.ErrResp(fdk.APIError{Code: http.StatusInternalServerError, Message: "failed to execute command - nil response"})
+	}
+
+	h.logger.Info("plugin execution completed", "status_code", execResp.Code())
+	if execResp.Payload == nil {
+		return fdk.ErrResp(fdk.APIError{Code: http.StatusInternalServerError, Message: "failed to execute command - empty response"})
+	}
+
+	resources := execResp.Payload.Resources
+	if len(resources) == 0 {
+		return fdk.ErrResp(fdk.APIError{Code: http.StatusInternalServerError, Message: "failed to execute command - empty resources in response payload"})
+	}
+
+	resource := resources[0]
+	resourceRespBody := resource.ResponseBody
+
+	snowSysID := ""
+	snowNumber := ""
+	errorText := ""
+
+	if result, ok := resourceRespBody.(map[string]interface{})["result"]; ok {
+		if resultMap, ok := result.(map[string]interface{}); ok {
+			if sysID, ok := resultMap["sys_id"].(string); ok {
+				snowSysID = sysID
+			}
+			if number, ok := resultMap["number"].(string); ok {
+				snowNumber = number
+			}
+		}
+	}
+
+	// Check if there's an error field in the response
+	if errorField, ok := resourceRespBody.(map[string]interface{})["error"]; ok {
+		if errorStr, ok := errorField.(string); ok {
+			errorText = errorStr
+		} else {
+			if errorBytes, err := json.Marshal(errorField); err == nil {
+				errorText = string(errorBytes)
+			} else {
+				errorText = fmt.Sprintf("Error field present but could not be parsed: %v", errorField)
+			}
+		}
+
+		errMsg := fmt.Sprintf("failed to execute command: ServiceNow Error: %s", errorText)
+		return fdk.ErrResp(fdk.APIError{Code: http.StatusInternalServerError, Message: errMsg})
+	}
+
+	h.logger.Info("updated ticket in ITSM", "ticket_id", snowSysID, "ticket_type", ticketType)
+
+	response := UpdateIncidentResponse{
+		TicketID:   snowSysID,
+		TicketType: ticketType,
+		Number:     snowNumber,
+	}
+
+	return fdk.Response{
+		Code: http.StatusOK,
+		Body: fdk.JSON(response),
+	}
+}
+
+// HandleUpdateIncident handles the /update_incident endpoint
+func (h *Handler) HandleUpdateIncident(ctx context.Context, r fdk.RequestOf[UpdateIncidentRequest], wrkCtx fdk.WorkflowCtx) fdk.Response {
+	return h.updateIncident(ctx, r, wrkCtx, pluginOpIDServiceNowUpdateIncident, "incident")
+}
+
+// HandleUpdateSIRIncident handles the /update_sir_incident endpoint
+func (h *Handler) HandleUpdateSIRIncident(ctx context.Context, r fdk.RequestOf[UpdateIncidentRequest], wrkCtx fdk.WorkflowCtx) fdk.Response {
+	return h.updateIncident(ctx, r, wrkCtx, pluginOpIDServiceNowUpdateSIRIncident, "sn_si_incident")
 }
 
 // handleThrottle handles the /throttle endpoint

--- a/functions/itsmhelper/internal/handler/handlers_test.go
+++ b/functions/itsmhelper/internal/handler/handlers_test.go
@@ -1741,6 +1741,439 @@ func (s *HandlerTestSuite) TestHandleCreateSIRIncident() {
 	}
 }
 
+// TestHandleUpdateIncident tests the Handler.HandleUpdateIncident method
+func (s *HandlerTestSuite) TestHandleUpdateIncident() {
+	tests := []struct {
+		name                     string
+		request                  fdk.RequestOf[UpdateIncidentRequest]
+		workflowCtx              fdk.WorkflowCtx
+		setupMockAPIIntegrations func(mockAPIIntegrations *MockAPIIntegrationsService)
+		setupMockClient          func() (*client.CrowdStrikeAPISpecification, string, error)
+		wantCode                 int
+		wantBody                 map[string]interface{}
+		wantErrors               []fdk.APIError
+	}{
+		{
+			name: "Successful update",
+			request: fdk.RequestOf[UpdateIncidentRequest]{
+				Body: UpdateIncidentRequest{
+					ConfigID:  "config123",
+					SysID:     "ticket123",
+					State:     "2",
+					WorkNotes: "Investigating",
+				},
+				AccessToken: "test-token",
+			},
+			workflowCtx: fdk.WorkflowCtx{},
+			setupMockAPIIntegrations: func(mockAPIIntegrations *MockAPIIntegrationsService) {
+				mockAPIIntegrations.ExecuteCommandFunc = func(params *api_integrations.ExecuteCommandParams, opts ...api_integrations.ClientOption) (*api_integrations.ExecuteCommandOK, error) {
+					// Verify correct operation ID
+					if params.Body.Resources[0].OperationID == nil || *params.Body.Resources[0].OperationID != pluginOpIDServiceNowUpdateIncident {
+						return nil, fmt.Errorf("expected operation ID %s", pluginOpIDServiceNowUpdateIncident)
+					}
+
+					// Verify sys_id is passed as a path parameter, not in the body
+					pathParams, ok := params.Body.Resources[0].Request.Params.Path.(map[string]interface{})
+					if !ok {
+						return nil, fmt.Errorf("expected path params to be a map[string]interface{}")
+					}
+					if pathParams["sys_id"] != "ticket123" {
+						return nil, fmt.Errorf("expected sys_id path param to be ticket123, got %v", pathParams["sys_id"])
+					}
+
+					// Verify sys_id is NOT in the JSON body
+					requestJSON, ok := params.Body.Resources[0].Request.JSON.(map[string]interface{})
+					if !ok {
+						return nil, fmt.Errorf("expected request JSON to be a map[string]interface{}")
+					}
+					if _, present := requestJSON["sys_id"]; present {
+						return nil, fmt.Errorf("sys_id should not be present in the JSON body")
+					}
+
+					result := map[string]interface{}{
+						"sys_id": "ticket123",
+						"number": "INC0010005",
+					}
+					return &api_integrations.ExecuteCommandOK{
+						Payload: &models.DomainExecuteCommandResultsV1{
+							Resources: []*models.DomainExecuteCommandResultV1{
+								{ResponseBody: map[string]interface{}{"result": result}},
+							},
+						},
+					}, nil
+				}
+			},
+			setupMockClient: func() (*client.CrowdStrikeAPISpecification, string, error) {
+				return &client.CrowdStrikeAPISpecification{}, "us-1", nil
+			},
+			wantCode: 200,
+			wantBody: map[string]interface{}{
+				"ticket_id":   "ticket123",
+				"ticket_type": "incident",
+				"number":      "INC0010005",
+			},
+		},
+		{
+			name: "Successful update with custom fields",
+			request: fdk.RequestOf[UpdateIncidentRequest]{
+				Body: UpdateIncidentRequest{
+					ConfigID:     "config123",
+					SysID:        "ticket456",
+					CustomFields: `{"u_custom_field1": "value1", "u_custom_field2": 42, "u_custom_field3": true}`,
+				},
+				AccessToken: "test-token",
+			},
+			workflowCtx: fdk.WorkflowCtx{},
+			setupMockAPIIntegrations: func(mockAPIIntegrations *MockAPIIntegrationsService) {
+				mockAPIIntegrations.ExecuteCommandFunc = func(params *api_integrations.ExecuteCommandParams, opts ...api_integrations.ClientOption) (*api_integrations.ExecuteCommandOK, error) {
+					requestJSON, ok := params.Body.Resources[0].Request.JSON.(map[string]interface{})
+					if !ok {
+						return nil, fmt.Errorf("expected request JSON to be a map[string]interface{}")
+					}
+					if requestJSON["u_custom_field1"] != "value1" ||
+						requestJSON["u_custom_field2"] != float64(42) ||
+						requestJSON["u_custom_field3"] != true {
+						return nil, fmt.Errorf("custom fields not properly included in request payload")
+					}
+
+					result := map[string]interface{}{
+						"sys_id": "ticket456",
+						"number": "INC0010006",
+					}
+					return &api_integrations.ExecuteCommandOK{
+						Payload: &models.DomainExecuteCommandResultsV1{
+							Resources: []*models.DomainExecuteCommandResultV1{
+								{ResponseBody: map[string]interface{}{"result": result}},
+							},
+						},
+					}, nil
+				}
+			},
+			setupMockClient: func() (*client.CrowdStrikeAPISpecification, string, error) {
+				return &client.CrowdStrikeAPISpecification{}, "us-1", nil
+			},
+			wantCode: 200,
+			wantBody: map[string]interface{}{
+				"ticket_id":   "ticket456",
+				"ticket_type": "incident",
+				"number":      "INC0010006",
+			},
+		},
+		{
+			name: "Falcon client creation error",
+			request: fdk.RequestOf[UpdateIncidentRequest]{
+				Body: UpdateIncidentRequest{
+					ConfigID: "config123",
+					SysID:    "ticket123",
+				},
+				AccessToken: "test-token",
+			},
+			workflowCtx:              fdk.WorkflowCtx{},
+			setupMockAPIIntegrations: func(mockAPIIntegrations *MockAPIIntegrationsService) {},
+			setupMockClient: func() (*client.CrowdStrikeAPISpecification, string, error) {
+				return nil, "", fmt.Errorf("client creation error")
+			},
+			wantCode: 500,
+			wantErrors: []fdk.APIError{
+				{
+					Code:    500,
+					Message: "error creating Falcon client: client creation error",
+				},
+			},
+		},
+		{
+			name: "Error executing ServiceNow command",
+			request: fdk.RequestOf[UpdateIncidentRequest]{
+				Body: UpdateIncidentRequest{
+					ConfigID: "config123",
+					SysID:    "ticket123",
+				},
+				AccessToken: "test-token",
+			},
+			workflowCtx: fdk.WorkflowCtx{},
+			setupMockAPIIntegrations: func(mockAPIIntegrations *MockAPIIntegrationsService) {
+				mockAPIIntegrations.ExecuteCommandFunc = func(params *api_integrations.ExecuteCommandParams, opts ...api_integrations.ClientOption) (*api_integrations.ExecuteCommandOK, error) {
+					return nil, fmt.Errorf("401 Unauthorized")
+				}
+			},
+			setupMockClient: func() (*client.CrowdStrikeAPISpecification, string, error) {
+				return &client.CrowdStrikeAPISpecification{}, "us-1", nil
+			},
+			wantCode: 500,
+			wantErrors: []fdk.APIError{
+				{
+					Code:    500,
+					Message: "failed to execute command: 401 Unauthorized",
+				},
+			},
+		},
+		{
+			name: "ServiceNow error field in response",
+			request: fdk.RequestOf[UpdateIncidentRequest]{
+				Body: UpdateIncidentRequest{
+					ConfigID: "config123",
+					SysID:    "ticket123",
+				},
+				AccessToken: "test-token",
+			},
+			workflowCtx: fdk.WorkflowCtx{},
+			setupMockAPIIntegrations: func(mockAPIIntegrations *MockAPIIntegrationsService) {
+				mockAPIIntegrations.ExecuteCommandFunc = func(params *api_integrations.ExecuteCommandParams, opts ...api_integrations.ClientOption) (*api_integrations.ExecuteCommandOK, error) {
+					return &api_integrations.ExecuteCommandOK{
+						Payload: &models.DomainExecuteCommandResultsV1{
+							Resources: []*models.DomainExecuteCommandResultV1{
+								{ResponseBody: map[string]interface{}{
+									"error": "Record not found",
+								}},
+							},
+						},
+					}, nil
+				}
+			},
+			setupMockClient: func() (*client.CrowdStrikeAPISpecification, string, error) {
+				return &client.CrowdStrikeAPISpecification{}, "us-1", nil
+			},
+			wantCode: 500,
+			wantErrors: []fdk.APIError{
+				{
+					Code:    500,
+					Message: "failed to execute command: ServiceNow Error: Record not found",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			s.SetupTest()
+
+			tc.setupMockAPIIntegrations(s.mockAPIIntegrations)
+
+			mockClientBuilder := func(token string, logger *slog.Logger) (*client.CrowdStrikeAPISpecification, string, error) {
+				client, cloud, err := tc.setupMockClient()
+				if client != nil && err == nil {
+					client.CustomStorage = s.mockStorage
+					client.APIIntegrations = s.mockAPIIntegrations
+				}
+				return client, cloud, err
+			}
+
+			handler := &Handler{
+				logger:           s.logger,
+				falconClientFunc: mockClientBuilder,
+			}
+
+			response := handler.HandleUpdateIncident(context.Background(), tc.request, tc.workflowCtx)
+			s.Equal(tc.wantCode, response.Code, "Response code should match expected value")
+
+			if len(tc.wantErrors) > 0 {
+				s.Nil(response.Body, "Response body should be nil for error responses")
+				s.NotEmpty(response.Errors, "Response errors should not be empty for error responses")
+				s.Len(response.Errors, len(tc.wantErrors), "Response should have the expected number of errors")
+				for i, wantErr := range tc.wantErrors {
+					s.Equal(wantErr.Code, response.Errors[i].Code, "Error code should match expected value")
+					s.Equal(wantErr.Message, response.Errors[i].Message, "Error message should match expected value")
+				}
+				return
+			}
+
+			jsonBytes, err := json.Marshal(response.Body)
+			s.NoError(err, "Failed to marshal JSON body")
+
+			var actual map[string]interface{}
+			err = json.Unmarshal(jsonBytes, &actual)
+			s.NoError(err, "Failed to unmarshal JSON body")
+
+			for k, v := range tc.wantBody {
+				actualVal, exists := actual[k]
+				s.True(exists, "Expected key %q not found in response", k)
+				s.Equal(v, actualVal, "For key %q, expected value should match actual value", k)
+			}
+		})
+	}
+}
+
+// TestHandleUpdateSIRIncident tests the Handler.HandleUpdateSIRIncident method
+func (s *HandlerTestSuite) TestHandleUpdateSIRIncident() {
+	tests := []struct {
+		name                     string
+		request                  fdk.RequestOf[UpdateIncidentRequest]
+		workflowCtx              fdk.WorkflowCtx
+		setupMockAPIIntegrations func(mockAPIIntegrations *MockAPIIntegrationsService)
+		setupMockClient          func() (*client.CrowdStrikeAPISpecification, string, error)
+		wantCode                 int
+		wantBody                 map[string]interface{}
+		wantErrors               []fdk.APIError
+	}{
+		{
+			name: "Successful SIR update with custom fields",
+			request: fdk.RequestOf[UpdateIncidentRequest]{
+				Body: UpdateIncidentRequest{
+					ConfigID:     "config123",
+					SysID:        "sir123",
+					State:        "2",
+					CustomFields: `{"u_security_category": "malware", "u_affected_systems": 3, "u_has_pii_data": true}`,
+				},
+				AccessToken: "test-token",
+			},
+			workflowCtx: fdk.WorkflowCtx{},
+			setupMockAPIIntegrations: func(mockAPIIntegrations *MockAPIIntegrationsService) {
+				mockAPIIntegrations.ExecuteCommandFunc = func(params *api_integrations.ExecuteCommandParams, opts ...api_integrations.ClientOption) (*api_integrations.ExecuteCommandOK, error) {
+					// Verify correct operation ID
+					if params.Body.Resources[0].OperationID == nil || *params.Body.Resources[0].OperationID != pluginOpIDServiceNowUpdateSIRIncident {
+						return nil, fmt.Errorf("expected operation ID %s", pluginOpIDServiceNowUpdateSIRIncident)
+					}
+
+					// Verify sys_id is passed as a path parameter
+					pathParams, ok := params.Body.Resources[0].Request.Params.Path.(map[string]interface{})
+					if !ok {
+						return nil, fmt.Errorf("expected path params to be a map[string]interface{}")
+					}
+					if pathParams["sys_id"] != "sir123" {
+						return nil, fmt.Errorf("expected sys_id path param to be sir123, got %v", pathParams["sys_id"])
+					}
+
+					requestJSON, ok := params.Body.Resources[0].Request.JSON.(map[string]interface{})
+					if !ok {
+						return nil, fmt.Errorf("expected request JSON to be a map[string]interface{}")
+					}
+					if requestJSON["u_security_category"] != "malware" ||
+						requestJSON["u_affected_systems"] != float64(3) ||
+						requestJSON["u_has_pii_data"] != true {
+						return nil, fmt.Errorf("custom fields not properly included in request payload")
+					}
+
+					result := map[string]interface{}{
+						"sys_id": "sir123",
+						"number": "SIR0010005",
+					}
+					return &api_integrations.ExecuteCommandOK{
+						Payload: &models.DomainExecuteCommandResultsV1{
+							Resources: []*models.DomainExecuteCommandResultV1{
+								{ResponseBody: map[string]interface{}{"result": result}},
+							},
+						},
+					}, nil
+				}
+			},
+			setupMockClient: func() (*client.CrowdStrikeAPISpecification, string, error) {
+				return &client.CrowdStrikeAPISpecification{}, "us-1", nil
+			},
+			wantCode: 200,
+			wantBody: map[string]interface{}{
+				"ticket_id":   "sir123",
+				"ticket_type": "sn_si_incident",
+				"number":      "SIR0010005",
+			},
+		},
+		{
+			name: "Falcon client creation error",
+			request: fdk.RequestOf[UpdateIncidentRequest]{
+				Body: UpdateIncidentRequest{
+					ConfigID: "config123",
+					SysID:    "sir123",
+				},
+				AccessToken: "test-token",
+			},
+			workflowCtx:              fdk.WorkflowCtx{},
+			setupMockAPIIntegrations: func(mockAPIIntegrations *MockAPIIntegrationsService) {},
+			setupMockClient: func() (*client.CrowdStrikeAPISpecification, string, error) {
+				return nil, "", fmt.Errorf("client creation error")
+			},
+			wantCode: 500,
+			wantErrors: []fdk.APIError{
+				{
+					Code:    500,
+					Message: "error creating Falcon client: client creation error",
+				},
+			},
+		},
+		{
+			name: "ServiceNow error field in response",
+			request: fdk.RequestOf[UpdateIncidentRequest]{
+				Body: UpdateIncidentRequest{
+					ConfigID: "config123",
+					SysID:    "sir123",
+				},
+				AccessToken: "test-token",
+			},
+			workflowCtx: fdk.WorkflowCtx{},
+			setupMockAPIIntegrations: func(mockAPIIntegrations *MockAPIIntegrationsService) {
+				mockAPIIntegrations.ExecuteCommandFunc = func(params *api_integrations.ExecuteCommandParams, opts ...api_integrations.ClientOption) (*api_integrations.ExecuteCommandOK, error) {
+					return &api_integrations.ExecuteCommandOK{
+						Payload: &models.DomainExecuteCommandResultsV1{
+							Resources: []*models.DomainExecuteCommandResultV1{
+								{ResponseBody: map[string]interface{}{
+									"error": "Record not found",
+								}},
+							},
+						},
+					}, nil
+				}
+			},
+			setupMockClient: func() (*client.CrowdStrikeAPISpecification, string, error) {
+				return &client.CrowdStrikeAPISpecification{}, "us-1", nil
+			},
+			wantCode: 500,
+			wantErrors: []fdk.APIError{
+				{
+					Code:    500,
+					Message: "failed to execute command: ServiceNow Error: Record not found",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			s.SetupTest()
+
+			tc.setupMockAPIIntegrations(s.mockAPIIntegrations)
+
+			mockClientBuilder := func(token string, logger *slog.Logger) (*client.CrowdStrikeAPISpecification, string, error) {
+				client, cloud, err := tc.setupMockClient()
+				if client != nil && err == nil {
+					client.CustomStorage = s.mockStorage
+					client.APIIntegrations = s.mockAPIIntegrations
+				}
+				return client, cloud, err
+			}
+
+			handler := &Handler{
+				logger:           s.logger,
+				falconClientFunc: mockClientBuilder,
+			}
+
+			response := handler.HandleUpdateSIRIncident(context.Background(), tc.request, tc.workflowCtx)
+			s.Equal(tc.wantCode, response.Code, "Response code should match expected value")
+
+			if len(tc.wantErrors) > 0 {
+				s.Nil(response.Body, "Response body should be nil for error responses")
+				s.NotEmpty(response.Errors, "Response errors should not be empty for error responses")
+				s.Len(response.Errors, len(tc.wantErrors), "Response should have the expected number of errors")
+				for i, wantErr := range tc.wantErrors {
+					s.Equal(wantErr.Code, response.Errors[i].Code, "Error code should match expected value")
+					s.Equal(wantErr.Message, response.Errors[i].Message, "Error message should match expected value")
+				}
+				return
+			}
+
+			jsonBytes, err := json.Marshal(response.Body)
+			s.NoError(err, "Failed to marshal JSON body")
+
+			var actual map[string]interface{}
+			err = json.Unmarshal(jsonBytes, &actual)
+			s.NoError(err, "Failed to unmarshal JSON body")
+
+			for k, v := range tc.wantBody {
+				actualVal, exists := actual[k]
+				s.True(exists, "Expected key %q not found in response", k)
+				s.Equal(v, actualVal, "For key %q, expected value should match actual value", k)
+			}
+		})
+	}
+}
+
 // TestExecuteCommandPayloadJSON verifies the JSON wire format of the execute command request.
 func (s *HandlerTestSuite) TestExecuteCommandPayloadJSON() {
 	tests := []struct {

--- a/functions/itsmhelper/main.go
+++ b/functions/itsmhelper/main.go
@@ -44,6 +44,16 @@ func newHandler(ctx context.Context, logger *slog.Logger, cfg config) fdk.Handle
 			return h.HandleCreateSIRIncident(ctx, r, wrkCtx)
 		})))
 
+	m.Post("/update_incident", fdk.HandleWorkflowOf(service.WithPanicRecoveryWorkflow(logger,
+		func(ctx context.Context, r fdk.RequestOf[handler.UpdateIncidentRequest], wrkCtx fdk.WorkflowCtx) fdk.Response {
+			return h.HandleUpdateIncident(ctx, r, wrkCtx)
+		})))
+
+	m.Post("/update_sir_incident", fdk.HandleWorkflowOf(service.WithPanicRecoveryWorkflow(logger,
+		func(ctx context.Context, r fdk.RequestOf[handler.UpdateIncidentRequest], wrkCtx fdk.WorkflowCtx) fdk.Response {
+			return h.HandleUpdateSIRIncident(ctx, r, wrkCtx)
+		})))
+
 	m.Post("/throttle", fdk.HandleFnOf(func(ctx context.Context, r fdk.RequestOf[handler.ThrottleFunctionRequest]) fdk.Response {
 		return h.HandleThrottle(ctx, r)
 	}))

--- a/functions/itsmhelper/main.py
+++ b/functions/itsmhelper/main.py
@@ -40,6 +40,8 @@ EXTERNAL_SYSTEM_ID_SERVICENOW_SIR_INCIDENT = "servicenow_sir_incident"
 PLUGIN_DEF_ID_SERVICENOW = "servicenow-foundry"
 PLUGIN_OP_ID_SERVICENOW_CREATE_INCIDENT = "create_incident"
 PLUGIN_OP_ID_SERVICENOW_CREATE_SIR_INCIDENT = "create_sn_si_incident"
+PLUGIN_OP_ID_SERVICENOW_UPDATE_INCIDENT = "update_incident"
+PLUGIN_OP_ID_SERVICENOW_UPDATE_SIR_INCIDENT = "update_sn_si_incident"
 
 # Collection names
 COLLECTION_NAME_TRACKED_ENTITIES = "tracked_entities"
@@ -334,6 +336,43 @@ def build_request_payload(body: Dict[str, Any]) -> Dict[str, Any]:
     optional_fields = [
         "assignment_group", "category", "description", "impact",
         "severity", "state", "urgency", "work_notes"
+    ]
+
+    for field in optional_fields:
+        if body.get(field):
+            request_payload[field] = body[field]
+
+    # Handle custom fields
+    custom_fields_str = body.get("custom_fields")
+    if custom_fields_str:
+        try:
+            custom_fields = json.loads(custom_fields_str) if isinstance(custom_fields_str, str) else custom_fields_str
+            request_payload.update(custom_fields)
+        except json.JSONDecodeError:
+            # Log but don't fail - custom fields are optional
+            pass
+
+    return request_payload
+
+
+def build_update_request_payload(body: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Build ServiceNow API request payload from update incident request.
+
+    Unlike build_request_payload, all fields are optional - only non-empty
+    fields are included in the payload.
+
+    Args:
+        body: Request body
+
+    Returns:
+        Request payload dictionary
+    """
+    request_payload: Dict[str, Any] = {}
+
+    optional_fields = [
+        "short_description", "assignment_group", "category", "description",
+        "impact", "severity", "state", "urgency", "work_notes"
     ]
 
     for field in optional_fields:
@@ -652,6 +691,173 @@ def create_sir_incident_handler(req: Request, _config: Optional[Dict[str, object
         PLUGIN_OP_ID_SERVICENOW_CREATE_SIR_INCIDENT,
         "sn_si_incident",
         EXTERNAL_SYSTEM_ID_SERVICENOW_SIR_INCIDENT
+    )
+
+
+def update_incident_impl(  # pylint: disable=too-many-locals,too-many-return-statements
+    req: Request,
+    logger: Logger,
+    operation_id: str,
+    ticket_type: str
+) -> Response:
+    """
+    Common implementation for updating incidents.
+
+    Args:
+        req: Request object
+        logger: Logger instance
+        operation_id: ServiceNow operation ID
+        ticket_type: Ticket type name
+
+    Returns:
+        Response object
+    """
+    try:
+        logger.info(
+            f"Updating {ticket_type} - trace_id: {req.trace_id}, workflow_ctx: {req.context}"
+        )
+
+        body = req.body
+        config_id = body.get("config_id")
+        sys_id = body.get("sys_id")
+
+        if not config_id or not sys_id:
+            return Response(
+                code=HTTPStatus.BAD_REQUEST,
+                errors=[APIError(
+                    code=HTTPStatus.BAD_REQUEST,
+                    message="Missing required fields: config_id, sys_id"
+                )]
+            )
+
+        api_integrations, _ = create_falcon_clients(logger)
+
+        # Build the update payload, flattening any custom fields into the root
+        request_payload = build_update_request_payload(body)
+
+        # Execute API integration command. sys_id is passed as a path parameter.
+        command_body = {
+            "resources": [{
+                "definition_id": PLUGIN_DEF_ID_SERVICENOW,
+                "operation_id": operation_id,
+                "config_id": config_id,
+                "request": {
+                    "json": request_payload,
+                    "params": {
+                        "path": {"sys_id": sys_id}
+                    }
+                }
+            }]
+        }
+
+        exec_response = api_integrations.execute_command(body=command_body)
+
+        status_code = exec_response.get("status_code")
+        logger.info(f"Plugin execution completed - status: {status_code}")
+
+        if status_code not in [200, 201]:
+            errors = exec_response.get("body", {}).get("errors", [])
+            error_msg = errors[0].get("message", "Unknown error") if errors else f"Status {status_code}"
+            logger.error(f"Failed to execute command: {error_msg}")
+            return Response(
+                code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                errors=[APIError(
+                    code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                    message=f"Failed to execute command: {error_msg}"
+                )]
+            )
+
+        # Parse response
+        resources = exec_response.get("body", {}).get("resources", [])
+        if not resources:
+            return Response(
+                code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                errors=[APIError(
+                    code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                    message="Empty response from ServiceNow"
+                )]
+            )
+
+        resource = resources[0]
+        response_body = resource.get("response_body", {})
+
+        # Check for errors
+        if "error" in response_body:
+            error_text = response_body["error"]
+            if isinstance(error_text, dict):
+                error_text = json.dumps(error_text)
+            logger.error(f"ServiceNow error: {error_text}")
+            return Response(
+                code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                errors=[APIError(
+                    code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                    message=f"ServiceNow Error: {error_text}"
+                )]
+            )
+
+        # Extract ticket information. The update response has no sys_class_name,
+        # so ticket_type is derived from the handler context.
+        result = response_body.get("result", {})
+        snow_sys_id = result.get("sys_id", "")
+        snow_number = result.get("number", "")
+
+        logger.info(f"Updated ticket in ITSM - ticket_id: {snow_sys_id}, ticket_type: {ticket_type}")
+
+        return Response(
+            code=HTTPStatus.OK,
+            body={
+                "ticket_id": snow_sys_id,
+                "ticket_type": ticket_type,
+                "number": snow_number
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"Error updating {ticket_type}: {str(e)}", exc_info=True)
+        return Response(
+            code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            errors=[APIError(
+                code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                message=f"Internal error: {str(e)}"
+            )]
+        )
+
+
+@FUNC.handler(path="/update_incident", method="POST")
+def update_incident_handler(req: Request, _config: Optional[Dict[str, object]], logger: Logger) -> Response:
+    """
+    Update a ServiceNow incident.
+
+    Request body:
+        - config_id: ServiceNow config ID
+        - sys_id: ServiceNow incident sys_id to update (required)
+        - short_description, assignment_group, category, description, impact,
+          severity, state, urgency, work_notes: Optional fields
+        - custom_fields: JSON string of custom fields
+    """
+    return update_incident_impl(
+        req, logger,
+        PLUGIN_OP_ID_SERVICENOW_UPDATE_INCIDENT,
+        "incident"
+    )
+
+
+@FUNC.handler(path="/update_sir_incident", method="POST")
+def update_sir_incident_handler(req: Request, _config: Optional[Dict[str, object]], logger: Logger) -> Response:
+    """
+    Update a ServiceNow SIR incident.
+
+    Request body:
+        - config_id: ServiceNow config ID
+        - sys_id: ServiceNow SIR incident sys_id to update (required)
+        - short_description, assignment_group, category, description, impact,
+          severity, state, urgency, work_notes: Optional fields
+        - custom_fields: JSON string of custom fields
+    """
+    return update_incident_impl(
+        req, logger,
+        PLUGIN_OP_ID_SERVICENOW_UPDATE_SIR_INCIDENT,
+        "sn_si_incident"
     )
 
 

--- a/functions/itsmhelper/schemas/update_incident_req_schema.json
+++ b/functions/itsmhelper/schemas/update_incident_req_schema.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "config_id": {
+      "description": "Config associated with activity when the workflow is triggered.",
+      "title": "Config",
+      "type": "string",
+      "ui:component": "async-select",
+      "x-cs-pivot": {
+        "entity": "plugins.config"
+      }
+    },
+    "sys_id": {
+      "type": "string",
+      "title": "Sys ID",
+      "description": "The unique identifier (sys_id) of the ServiceNow incident to update."
+    },
+    "assignment_group": {
+      "title": "Assignment group",
+      "type": "string",
+      "x-cs-pivot": {
+        "entity": "plugins.proxy.425a02a359bd49ed92be2075a98898bc.get_groups",
+        "searchable": true
+      }
+    },
+    "category": {
+      "title": "Category",
+      "type": "string",
+      "x-cs-pivot": {
+        "entity": "plugins.proxy.425a02a359bd49ed92be2075a98898bc.get_incident_category"
+      }
+    },
+    "description": {
+      "type": "string",
+      "title": "Description",
+      "ui:component": "text-area"
+    },
+    "impact": {
+      "title": "Impact",
+      "type": "string",
+      "x-cs-pivot": {
+        "entity": "plugins.proxy.425a02a359bd49ed92be2075a98898bc.get_task_impact"
+      }
+    },
+    "severity": {
+      "title": "Severity",
+      "type": "string",
+      "x-cs-pivot": {
+        "entity": "plugins.proxy.425a02a359bd49ed92be2075a98898bc.get_incident_severity"
+      }
+    },
+    "short_description": {
+      "type": "string",
+      "title": "Short description",
+      "ui:component": "text-area"
+    },
+    "state": {
+      "title": "State",
+      "type": "string",
+      "x-cs-pivot": {
+        "entity": "plugins.proxy.425a02a359bd49ed92be2075a98898bc.get_incident_state"
+      }
+    },
+    "urgency": {
+      "title": "Urgency",
+      "type": "string",
+      "x-cs-pivot": {
+        "entity": "plugins.proxy.425a02a359bd49ed92be2075a98898bc.get_task_urgency"
+      }
+    },
+    "work_notes": {
+      "title": "Work notes",
+      "type": "string",
+      "ui:component": "text-area"
+    },
+    "custom_fields": {
+      "title": "Custom Fields JSON (advanced)",
+      "description": "ServiceNow custom fields as key-value pairs (e.g., {\"u_custom_field\": \"value\"})",
+      "type": "string",
+      "format": "rawJSON",
+      "pattern": "^(\\s*\\{[\\s\\S]*\\}\\s*|\\$\\{[a-zA-Z0-9_.]+\\})$",
+      "ui:component": "text-area"
+    }
+  },
+  "required": [
+    "config_id",
+    "sys_id"
+  ],
+  "x-cs-order": [
+    "config_id",
+    "sys_id",
+    "short_description",
+    "assignment_group",
+    "category",
+    "impact",
+    "state",
+    "urgency",
+    "work_notes",
+    "custom_fields"
+  ]
+}

--- a/functions/itsmhelper/schemas/update_incident_resp_schema.json
+++ b/functions/itsmhelper/schemas/update_incident_resp_schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "ticket_id": {
+      "type": "string",
+      "title": "Ticket ID"
+    },
+    "ticket_type": {
+      "type": "string",
+      "title": "Ticket Type"
+    },
+    "number": {
+      "type": "string",
+      "title": "Number"
+    }
+  },
+  "additionalProperties": false
+}

--- a/functions/itsmhelper/schemas/update_sir_incident_req_schema.json
+++ b/functions/itsmhelper/schemas/update_sir_incident_req_schema.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "config_id": {
+      "description": "Config associated with activity when the workflow is triggered.",
+      "title": "Config",
+      "type": "string",
+      "ui:component": "async-select",
+      "x-cs-pivot": {
+        "entity": "plugins.config"
+      }
+    },
+    "sys_id": {
+      "type": "string",
+      "title": "Sys ID",
+      "description": "The unique identifier (sys_id) of the ServiceNow SIR incident to update."
+    },
+    "assignment_group": {
+      "title": "Assignment group",
+      "type": "string",
+      "x-cs-pivot": {
+        "entity": "plugins.proxy.425a02a359bd49ed92be2075a98898bc.get_groups",
+        "searchable": true
+      }
+    },
+    "category": {
+      "title": "Category",
+      "type": "string",
+      "x-cs-pivot": {
+        "entity": "plugins.proxy.425a02a359bd49ed92be2075a98898bc.get_sn_si_incident_category"
+      }
+    },
+    "description": {
+      "type": "string",
+      "title": "Description",
+      "ui:component": "text-area"
+    },
+    "impact": {
+      "title": "Impact",
+      "type": "string",
+      "x-cs-pivot": {
+        "entity": "plugins.proxy.425a02a359bd49ed92be2075a98898bc.get_task_impact"
+      }
+    },
+    "severity": {
+      "title": "Severity",
+      "type": "string",
+      "x-cs-pivot": {
+        "entity": "plugins.proxy.425a02a359bd49ed92be2075a98898bc.get_sn_si_incident_severity"
+      }
+    },
+    "short_description": {
+      "type": "string",
+      "title": "Short description",
+      "ui:component": "text-area"
+    },
+    "state": {
+      "title": "State",
+      "type": "string",
+      "x-cs-pivot": {
+        "entity": "plugins.proxy.425a02a359bd49ed92be2075a98898bc.get_sn_si_incident_state"
+      }
+    },
+    "urgency": {
+      "title": "Urgency",
+      "type": "string",
+      "x-cs-pivot": {
+        "entity": "plugins.proxy.425a02a359bd49ed92be2075a98898bc.get_task_urgency"
+      }
+    },
+    "work_notes": {
+      "title": "Work notes",
+      "type": "string",
+      "ui:component": "text-area"
+    },
+    "custom_fields": {
+      "title": "Custom Fields JSON (advanced)",
+      "description": "ServiceNow custom fields as key-value pairs (e.g., {\"u_custom_field\": \"value\"})",
+      "type": "string",
+      "format": "rawJSON",
+      "pattern": "^(\\s*\\{[\\s\\S]*\\}\\s*|\\$\\{[a-zA-Z0-9_.]+\\})$",
+      "ui:component": "text-area"
+    }
+  },
+  "required": [
+    "config_id",
+    "sys_id"
+  ],
+  "x-cs-order": [
+    "config_id",
+    "sys_id",
+    "short_description",
+    "assignment_group",
+    "category",
+    "impact",
+    "state",
+    "urgency",
+    "work_notes",
+    "custom_fields"
+  ]
+}

--- a/functions/itsmhelper/schemas/update_sir_incident_resp_schema.json
+++ b/functions/itsmhelper/schemas/update_sir_incident_resp_schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "ticket_id": {
+      "type": "string",
+      "title": "Ticket ID"
+    },
+    "ticket_type": {
+      "type": "string",
+      "title": "Ticket Type"
+    },
+    "number": {
+      "type": "string",
+      "title": "Number"
+    }
+  },
+  "additionalProperties": false
+}

--- a/functions/itsmhelper/test_main.py
+++ b/functions/itsmhelper/test_main.py
@@ -651,6 +651,219 @@ class TestCreateIncidentHandlers(unittest.TestCase):
         self.assertEqual(response.code, HTTPStatus.BAD_REQUEST)
 
 
+class TestBuildUpdateRequestPayload(unittest.TestCase):
+    """Test build_update_request_payload function"""
+
+    def test_empty_payload(self):
+        body = {"config_id": "config123", "sys_id": "ticket123"}
+        result = main.build_update_request_payload(body)
+
+        # config_id and sys_id are not part of the ServiceNow payload
+        self.assertEqual(result, {})
+
+    def test_partial_payload(self):
+        body = {"state": "2", "work_notes": "Investigating"}
+        result = main.build_update_request_payload(body)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result["state"], "2")
+        self.assertEqual(result["work_notes"], "Investigating")
+
+    def test_full_payload(self):
+        body = {
+            "short_description": "Updated incident",
+            "assignment_group": "IT Support",
+            "category": "Software",
+            "description": "Full description",
+            "impact": "2",
+            "severity": "3",
+            "state": "1",
+            "urgency": "2",
+            "work_notes": "Initial notes"
+        }
+        result = main.build_update_request_payload(body)
+
+        self.assertEqual(len(result), 9)
+        self.assertEqual(result["short_description"], "Updated incident")
+        self.assertEqual(result["impact"], "2")
+
+    def test_payload_with_custom_fields(self):
+        body = {
+            "state": "2",
+            "custom_fields": '{"custom_field1": "value1", "custom_field2": "value2"}'
+        }
+        result = main.build_update_request_payload(body)
+
+        self.assertEqual(result["state"], "2")
+        self.assertEqual(result["custom_field1"], "value1")
+        self.assertEqual(result["custom_field2"], "value2")
+
+
+class TestUpdateIncidentHandlers(unittest.TestCase):
+    """Test update_incident_handler and update_sir_incident_handler"""
+
+    @patch('main.create_falcon_clients')
+    def test_update_incident_success(self, mock_create_clients):
+        mock_logger = Mock()
+        mock_api_integrations = Mock()
+        mock_client = Mock()
+        mock_create_clients.return_value = (mock_api_integrations, mock_client)
+
+        mock_api_integrations.execute_command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [{
+                    "response_body": {
+                        "result": {
+                            "sys_id": "ticket123",
+                            "number": "INC0010005"
+                        }
+                    }
+                }]
+            }
+        }
+
+        mock_request = Mock()
+        mock_request.trace_id = "trace-123"
+        mock_request.context = {}
+        mock_request.body = {
+            "config_id": "config123",
+            "sys_id": "ticket123",
+            "state": "2",
+            "work_notes": "Investigating"
+        }
+
+        response = main.update_incident_handler(mock_request, None, mock_logger)
+
+        self.assertEqual(response.code, HTTPStatus.OK)
+        self.assertEqual(response.body["ticket_id"], "ticket123")
+        self.assertEqual(response.body["ticket_type"], "incident")
+        self.assertEqual(response.body["number"], "INC0010005")
+
+        # Verify sys_id is passed as a path parameter, not in the JSON body
+        call_args = mock_api_integrations.execute_command.call_args[1]
+        request = call_args["body"]["resources"][0]["request"]
+        self.assertEqual(request["params"]["path"]["sys_id"], "ticket123")
+        self.assertNotIn("sys_id", request["json"])
+        self.assertEqual(call_args["body"]["resources"][0]["operation_id"],
+                         main.PLUGIN_OP_ID_SERVICENOW_UPDATE_INCIDENT)
+
+    @patch('main.create_falcon_clients')
+    def test_update_sir_incident_success_with_custom_fields(self, mock_create_clients):
+        mock_logger = Mock()
+        mock_api_integrations = Mock()
+        mock_client = Mock()
+        mock_create_clients.return_value = (mock_api_integrations, mock_client)
+
+        mock_api_integrations.execute_command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [{
+                    "response_body": {
+                        "result": {
+                            "sys_id": "sir123",
+                            "number": "SIR0010005"
+                        }
+                    }
+                }]
+            }
+        }
+
+        mock_request = Mock()
+        mock_request.trace_id = "trace-123"
+        mock_request.context = {}
+        mock_request.body = {
+            "config_id": "config123",
+            "sys_id": "sir123",
+            "custom_fields": '{"u_security_category": "malware"}'
+        }
+
+        response = main.update_sir_incident_handler(mock_request, None, mock_logger)
+
+        self.assertEqual(response.code, HTTPStatus.OK)
+        self.assertEqual(response.body["ticket_id"], "sir123")
+        self.assertEqual(response.body["ticket_type"], "sn_si_incident")
+
+        # Verify custom fields are flattened and correct operation ID is used
+        call_args = mock_api_integrations.execute_command.call_args[1]
+        request = call_args["body"]["resources"][0]["request"]
+        self.assertEqual(request["json"]["u_security_category"], "malware")
+        self.assertEqual(call_args["body"]["resources"][0]["operation_id"],
+                         main.PLUGIN_OP_ID_SERVICENOW_UPDATE_SIR_INCIDENT)
+
+    @patch('main.create_falcon_clients')
+    def test_update_execute_command_failure(self, mock_create_clients):
+        mock_logger = Mock()
+        mock_api_integrations = Mock()
+        mock_client = Mock()
+        mock_create_clients.return_value = (mock_api_integrations, mock_client)
+
+        mock_api_integrations.execute_command.return_value = {
+            "status_code": 403,
+            "body": {
+                "errors": [{"message": "received invalid status code from plugin: 403"}]
+            }
+        }
+
+        mock_request = Mock()
+        mock_request.trace_id = "trace-123"
+        mock_request.context = {}
+        mock_request.body = {
+            "config_id": "config123",
+            "sys_id": "ticket123"
+        }
+
+        response = main.update_incident_handler(mock_request, None, mock_logger)
+
+        self.assertEqual(response.code, HTTPStatus.INTERNAL_SERVER_ERROR)
+        self.assertIn("403", response.errors[0].message)
+
+    @patch('main.create_falcon_clients')
+    def test_update_servicenow_error_response(self, mock_create_clients):
+        mock_logger = Mock()
+        mock_api_integrations = Mock()
+        mock_client = Mock()
+        mock_create_clients.return_value = (mock_api_integrations, mock_client)
+
+        mock_api_integrations.execute_command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [{
+                    "response_body": {
+                        "error": "Record not found"
+                    }
+                }]
+            }
+        }
+
+        mock_request = Mock()
+        mock_request.trace_id = "trace-123"
+        mock_request.context = {}
+        mock_request.body = {
+            "config_id": "config123",
+            "sys_id": "ticket123"
+        }
+
+        response = main.update_incident_handler(mock_request, None, mock_logger)
+
+        self.assertEqual(response.code, HTTPStatus.INTERNAL_SERVER_ERROR)
+        self.assertIn("ServiceNow Error", response.errors[0].message)
+
+    def test_update_missing_required_fields(self):
+        mock_logger = Mock()
+        mock_request = Mock()
+        mock_request.trace_id = "trace-123"
+        mock_request.context = {}
+        mock_request.body = {
+            "config_id": "config123"
+            # Missing sys_id
+        }
+
+        response = main.update_incident_handler(mock_request, None, mock_logger)
+
+        self.assertEqual(response.code, HTTPStatus.BAD_REQUEST)
+
+
 class TestThrottleHandler(unittest.TestCase):
     """Test throttle_handler"""
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -111,6 +111,32 @@ functions:
           tags:
             - ServiceNow Foundry
         permissions: []
+      - name: ITSM Helper - Update Incident
+        description: Helper function that updates an incident in the ServiceNow ITSM system, including custom fields
+        method: POST
+        api_path: /update_incident
+        payload_type: ""
+        request_schema: schemas/update_incident_req_schema.json
+        response_schema: schemas/update_incident_resp_schema.json
+        workflow_integration:
+          disruptive: false
+          system_action: false
+          tags:
+            - ServiceNow Foundry
+        permissions: []
+      - name: ITSM Helper - Update SIR Incident
+        description: Helper function that updates an SIR incident in the ServiceNow ITSM system, including custom fields
+        method: POST
+        api_path: /update_sir_incident
+        payload_type: ""
+        request_schema: schemas/update_sir_incident_req_schema.json
+        response_schema: schemas/update_sir_incident_resp_schema.json
+        workflow_integration:
+          disruptive: false
+          system_action: false
+          tags:
+            - ServiceNow Foundry
+        permissions: []
       - name: ITSM Helper - Throttle
         description: Helper function that throttles the flow of updates to downstream workflow nodes
         method: POST


### PR DESCRIPTION
Adds two function-wrapped actions, "ITSM Helper - Update Incident" and "ITSM Helper - Update SIR Incident", that flatten a `custom_fields` JSON string into top-level fields before calling ServiceNow, giving updates the same arbitrary-field support the create actions already have.

## Test plan
- [x] Go: `go vet` + `go test ./...` pass
- [x] Python: `pytest` passes
- [ ] E2E test
- [ ] Re-capture update-workflow screenshots