### PR TITLE
fix(e2e): handle auth type dropdown with 3+ options

### DIFF
--- a/e2e/tests/app-install.setup.ts
+++ b/e2e/tests/app-install.setup.ts
@@ -23,7 +23,10 @@ setup('install app', async ({ page }) => {
       await listbox.waitFor({ state: 'visible', timeout: 5000 });
       const options = listbox.getByRole('option');
       const count = await options.count();
-      await listbox.press('ArrowUp');
+      // Press ArrowUp enough times to guarantee focus is at the top
+      for (let j = 0; j < count; j++) {
+        await listbox.press('ArrowUp');
+      }
       for (let i = 0; i < count; i++) {
         if ((await options.nth(i).textContent())?.trim() === 'Basic Authentication') break;
         await listbox.press('ArrowDown');


### PR DESCRIPTION
PR #83 added a third authentication option (OAuth 2.0 JWT Bearer) to the auth type dropdown. This broke the E2E test's keyboard navigation logic for selecting Basic Authentication.

The test presses ArrowUp once to reach the top of the dropdown, then iterates down to find "Basic Authentication" by name. With only 2 options this worked, but with 3 options a single ArrowUp from the bottom only reaches position 1 (not 0). The keyboard focus and DOM index get out of sync, causing the wrong auth type to be selected. The Username/Password fields then never render, and the test times out.

The fix presses ArrowUp `count` times to guarantee focus starts at the top regardless of how many options exist. Verified locally with all 4 tests passing.