### PR TITLE
Add explicit Content-Type header to API integration operations

### DIFF
--- a/api-integrations/servicenow.json
+++ b/api-integrations/servicenow.json
@@ -350,6 +350,15 @@
                 "skip": true
               }
             }
+          },
+          {
+            "in": "header",
+            "name": "Content-Type",
+            "schema": {
+              "default": "application/json",
+              "title": "Content-Type",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -524,6 +533,15 @@
             "schema": {
               "description": "The unique identifier for the incident",
               "title": "Sys ID",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Content-Type",
+            "schema": {
+              "default": "application/json",
+              "title": "Content-Type",
               "type": "string"
             }
           }
@@ -753,6 +771,15 @@
                 "skip": true
               }
             }
+          },
+          {
+            "in": "header",
+            "name": "Content-Type",
+            "schema": {
+              "default": "application/json",
+              "title": "Content-Type",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -927,6 +954,15 @@
             "schema": {
               "description": "The unique identifier for the SIR incident",
               "title": "Sys ID",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Content-Type",
+            "schema": {
+              "default": "application/json",
+              "title": "Content-Type",
               "type": "string"
             }
           }
@@ -1176,6 +1212,15 @@
                 "skip": true
               }
             }
+          },
+          {
+            "in": "header",
+            "name": "Content-Type",
+            "schema": {
+              "default": "application/json",
+              "title": "Content-Type",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -1293,6 +1338,15 @@
               "x-cs-ui": {
                 "skip": true
               }
+            }
+          },
+          {
+            "in": "header",
+            "name": "Content-Type",
+            "schema": {
+              "default": "application/json",
+              "title": "Content-Type",
+              "type": "string"
             }
           }
         ],


### PR DESCRIPTION
The `create_sn_si_incident` and other POST/PATCH operations were missing an explicit `Content-Type: application/json` header parameter, while `create_problem` had one. This caused the Go runtime (go-openapi) to fail with "no producer registered for content type multipart/form-data" when creating SIR incidents via workflows.

This adds the `Content-Type` header to all JSON POST/PATCH operations that were missing it:

- `create_incident`
- `update_incident`
- `create_sn_si_incident`
- `update_sn_si_incident`
- `link_observable_to_sir_incident`
- `create_sir_observable`

The fix matches the existing pattern already used by `create_problem`, which was the only operation that had the header and worked correctly.