### PR TITLE
Remove personal contact email from API integration spec

### DIFF
--- a/api-integrations/servicenow.json
+++ b/api-integrations/servicenow.json
@@ -277,9 +277,6 @@
     }
   },
   "info": {
-    "contact": {
-      "email": "roman.nekhoroshev@crowdstrike.com"
-    },
     "title": "ServiceNow",
     "version": ""
   },


### PR DESCRIPTION
## Summary

Removes the `info.contact.email` field from the OpenAPI spec(s) in `api-integrations/`. This field contained a personal CrowdStrike employee email address, which is inappropriate to expose in a public repository.

The field is optional per the OpenAPI specification and is not used by Foundry at runtime.

## Change

- Removed `"contact": { "email": "..." }` block from `info` section
- No functional change — spec behaviour is identical