### PR TITLE
feat: expose ServiceNow ticket numbers in create incident responses

### DIFF
--- a/functions/itsmhelper/internal/handler/handlers.go
+++ b/functions/itsmhelper/internal/handler/handlers.go
@@ -13,7 +13,12 @@ import (
 	"github.com/crowdstrike/gofalcon/falcon/client"
 	"github.com/crowdstrike/gofalcon/falcon/client/api_integrations"
 	"github.com/crowdstrike/gofalcon/falcon/models"
+	"github.com/go-openapi/runtime"
 )
+
+func withJSONContentType(op *runtime.ClientOperation) {
+	op.ConsumesMediaTypes = []string{"application/json"}
+}
 
 const (
 	ExternalSystemIDServiceNowIncident    = "servicenow_incident"
@@ -58,9 +63,10 @@ type CreateIncidentRequest struct {
 
 // CreateIncidentResponse represents the response body for creating an incident
 type CreateIncidentResponse struct {
-	Exists     bool   `json:"exists"`
-	TicketID   string `json:"ticket_id"`
-	TicketType string `json:"ticket_type"`
+	Exists       bool   `json:"exists"`
+	TicketID     string `json:"ticket_id"`
+	TicketNumber string `json:"ticket_number"`
+	TicketType   string `json:"ticket_type"`
 }
 
 // ThrottleFunctionRequest represents the schema for deduplication requests
@@ -257,7 +263,7 @@ func (h *Handler) createIncident(
 		Context: ctx,
 	}
 
-	execResp, err := falconClient.APIIntegrations.ExecuteCommand(execCmdParams)
+	execResp, err := falconClient.APIIntegrations.ExecuteCommand(execCmdParams, withJSONContentType)
 	if err != nil {
 		errMsg := fmt.Sprintf("failed to execute command: %v", err)
 		return fdk.ErrResp(fdk.APIError{Code: http.StatusInternalServerError, Message: errMsg})
@@ -282,6 +288,7 @@ func (h *Handler) createIncident(
 
 	snowSysClassName := ""
 	snowSysID := ""
+	snowNumber := ""
 	errorText := ""
 
 	if result, ok := resourceRespBody.(map[string]interface{})["result"]; ok {
@@ -294,6 +301,11 @@ func (h *Handler) createIncident(
 			// Try to get sys_id
 			if sysID, ok := resultMap["sys_id"].(string); ok {
 				snowSysID = sysID
+			}
+
+			// Try to get number (human-readable ticket number like INC0010001)
+			if number, ok := resultMap["number"].(string); ok {
+				snowNumber = number
 			}
 		}
 	}
@@ -316,7 +328,7 @@ func (h *Handler) createIncident(
 		return fdk.ErrResp(fdk.APIError{Code: http.StatusInternalServerError, Message: errMsg})
 	}
 
-	h.logger.Info("received response from ITSM", "ticket_id", snowSysID, "ticket_type", snowSysClassName)
+	h.logger.Info("received response from ITSM", "ticket_id", snowSysID, "ticket_number", snowNumber, "ticket_type", snowSysClassName)
 
 	// If we successfully created a ticket, store the mapping
 	if snowSysID != "" {
@@ -336,9 +348,10 @@ func (h *Handler) createIncident(
 	}
 
 	response := CreateIncidentResponse{
-		TicketID:   snowSysID,
-		TicketType: snowSysClassName,
-		Exists:     false,
+		TicketID:     snowSysID,
+		TicketNumber: snowNumber,
+		TicketType:   snowSysClassName,
+		Exists:       false,
 	}
 
 	return fdk.Response{

--- a/functions/itsmhelper/internal/handler/handlers_test.go
+++ b/functions/itsmhelper/internal/handler/handlers_test.go
@@ -732,9 +732,10 @@ func (s *HandlerTestSuite) TestHandleCreateIncident() {
 			},
 			wantCode: 200,
 			wantBody: map[string]interface{}{
-				"exists":      true,
-				"ticket_id":   "ticket123",
-				"ticket_type": "incident",
+				"exists":        true,
+				"ticket_id":     "ticket123",
+				"ticket_number": "",
+				"ticket_type":   "incident",
 			},
 		},
 		{
@@ -803,9 +804,10 @@ func (s *HandlerTestSuite) TestHandleCreateIncident() {
 			},
 			wantCode: 201,
 			wantBody: map[string]interface{}{
-				"exists":      false,
-				"ticket_id":   "c2a8a7e5db14301094ed6bfa4b9619d3",
-				"ticket_type": "incident",
+				"exists":        false,
+				"ticket_id":     "c2a8a7e5db14301094ed6bfa4b9619d3",
+				"ticket_number": "INC0010005",
+				"ticket_type":   "incident",
 			},
 		},
 		{
@@ -876,9 +878,10 @@ func (s *HandlerTestSuite) TestHandleCreateIncident() {
 			},
 			wantCode: 201,
 			wantBody: map[string]interface{}{
-				"exists":      false,
-				"ticket_id":   "c2a8a7e5db14301094ed6bfa4b9619d4",
-				"ticket_type": "incident",
+				"exists":        false,
+				"ticket_id":     "c2a8a7e5db14301094ed6bfa4b9619d4",
+				"ticket_number": "INC0010006",
+				"ticket_type":   "incident",
 			},
 		},
 		{
@@ -1319,9 +1322,10 @@ func (s *HandlerTestSuite) TestHandleCreateSIRIncident() {
 			},
 			wantCode: 200,
 			wantBody: map[string]interface{}{
-				"exists":      true,
-				"ticket_id":   "ticket123",
-				"ticket_type": "sn_si_incident",
+				"exists":        true,
+				"ticket_id":     "ticket123",
+				"ticket_number": "",
+				"ticket_type":   "sn_si_incident",
 			},
 		},
 		{
@@ -1398,9 +1402,10 @@ func (s *HandlerTestSuite) TestHandleCreateSIRIncident() {
 			},
 			wantCode: 201,
 			wantBody: map[string]interface{}{
-				"exists":      false,
-				"ticket_id":   "c2a8a7e5db14301094ed6bfa4b9619d4",
-				"ticket_type": "sn_si_incident",
+				"exists":        false,
+				"ticket_id":     "c2a8a7e5db14301094ed6bfa4b9619d4",
+				"ticket_number": "SIR0010005",
+				"ticket_type":   "sn_si_incident",
 			},
 		},
 		{
@@ -1480,9 +1485,10 @@ func (s *HandlerTestSuite) TestHandleCreateSIRIncident() {
 			},
 			wantCode: 201,
 			wantBody: map[string]interface{}{
-				"exists":      false,
-				"ticket_id":   "c2a8a7e5db14301094ed6bfa4b9619d5",
-				"ticket_type": "sn_si_incident",
+				"exists":        false,
+				"ticket_id":     "c2a8a7e5db14301094ed6bfa4b9619d5",
+				"ticket_number": "SIR0010006",
+				"ticket_type":   "sn_si_incident",
 			},
 		},
 		{

--- a/functions/itsmhelper/main.py
+++ b/functions/itsmhelper/main.py
@@ -517,6 +517,7 @@ def create_incident_impl(  # pylint: disable=too-many-locals,too-many-return-sta
                 body={
                     "exists": True,
                     "ticket_id": ext_record.get("external_entity_id"),
+                    "ticket_number": "",
                     "ticket_type": ticket_type
                 }
             )
@@ -585,8 +586,9 @@ def create_incident_impl(  # pylint: disable=too-many-locals,too-many-return-sta
         result = response_body.get("result", {})
         snow_sys_class_name = result.get("sys_class_name", "")
         snow_sys_id = result.get("sys_id", "")
+        snow_number = result.get("number", "")
 
-        logger.info(f"Received response from ITSM - ticket_id: {snow_sys_id}, ticket_type: {snow_sys_class_name}")
+        logger.info(f"Received response from ITSM - ticket_id: {snow_sys_id}, ticket_number: {snow_number}, ticket_type: {snow_sys_class_name}")
 
         # Store entity mapping
         if snow_sys_id:
@@ -600,6 +602,7 @@ def create_incident_impl(  # pylint: disable=too-many-locals,too-many-return-sta
             body={
                 "exists": False,
                 "ticket_id": snow_sys_id,
+                "ticket_number": snow_number,
                 "ticket_type": snow_sys_class_name
             }
         )

--- a/functions/itsmhelper/schemas/create_incident_resp_schema.json
+++ b/functions/itsmhelper/schemas/create_incident_resp_schema.json
@@ -9,7 +9,13 @@
     },
     "ticket_id": {
       "type": "string",
-      "title": "Ticket ID"
+      "title": "Ticket ID",
+      "description": "ServiceNow sys_id of the ticket"
+    },
+    "ticket_number": {
+      "type": "string",
+      "title": "Ticket Number",
+      "description": "Human-readable ServiceNow ticket number (e.g. INC0010001)"
     },
     "ticket_type": {
       "type": "string",

--- a/functions/itsmhelper/schemas/create_sir_incident_resp_schema.json
+++ b/functions/itsmhelper/schemas/create_sir_incident_resp_schema.json
@@ -9,7 +9,13 @@
     },
     "ticket_id": {
       "type": "string",
-      "title": "Ticket ID"
+      "title": "Ticket ID",
+      "description": "ServiceNow sys_id of the ticket"
+    },
+    "ticket_number": {
+      "type": "string",
+      "title": "Ticket Number",
+      "description": "Human-readable ServiceNow ticket number (e.g. SIR0010001)"
     },
     "ticket_type": {
       "type": "string",

--- a/functions/itsmhelper/test_main.py
+++ b/functions/itsmhelper/test_main.py
@@ -466,6 +466,7 @@ class TestCreateIncidentHandlers(unittest.TestCase):
         self.assertEqual(response.code, HTTPStatus.OK)
         self.assertTrue(response.body["exists"])
         self.assertEqual(response.body["ticket_id"], "existing-ticket-123")
+        self.assertEqual(response.body["ticket_number"], "")
         # Should not call API integration if ticket exists
         mock_api_integrations.execute_command.assert_not_called()
 
@@ -489,6 +490,7 @@ class TestCreateIncidentHandlers(unittest.TestCase):
                     "response_body": {
                         "result": {
                             "sys_id": "new-ticket-123",
+                            "number": "INC0010001",
                             "sys_class_name": "incident"
                         }
                     }
@@ -511,6 +513,7 @@ class TestCreateIncidentHandlers(unittest.TestCase):
         self.assertEqual(response.code, HTTPStatus.CREATED)
         self.assertFalse(response.body["exists"])
         self.assertEqual(response.body["ticket_id"], "new-ticket-123")
+        self.assertEqual(response.body["ticket_number"], "INC0010001")
         self.assertEqual(response.body["ticket_type"], "incident")
 
         # Verify API integration was called
@@ -541,6 +544,7 @@ class TestCreateIncidentHandlers(unittest.TestCase):
                     "response_body": {
                         "result": {
                             "sys_id": "new-ticket-456",
+                            "number": "INC0010002",
                             "sys_class_name": "incident"
                         }
                     }
@@ -567,6 +571,7 @@ class TestCreateIncidentHandlers(unittest.TestCase):
         self.assertEqual(response.code, HTTPStatus.CREATED)
         self.assertFalse(response.body["exists"])
         self.assertEqual(response.body["ticket_id"], "new-ticket-456")
+        self.assertEqual(response.body["ticket_number"], "INC0010002")
         mock_api_integrations.execute_command.assert_called_once()
 
     @patch('main.create_falcon_clients')


### PR DESCRIPTION
Changes:

- Ticket number parsing - Parse the human-readable ticket number (e.g. INC0010001, SIR0010001) from ServiceNow API responses and include it alongside the sys_id in both Go and Python handler implementations.
-  Go version patch - `withJSONContentType` fix for the API integration `ExecuteCommand` call